### PR TITLE
Ability to use multiple USDT or BTC bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ The `watchlist` bot helper has a different layout:
 -   **timezone** - timezone. (default is 'Europe/Amsterdam')
 -   **debug** - set to true to enable debug logging to file. (default is False)
 -   **logrotate** - number of days to keep logs. (default = 7)
--   **usdt-botid** - the bot id of the USDT multipair bot to use. (can also be using BUSD)
--   **btc-botid** -  the bot id of the BTC multipair bot to use.
+-   **usdt-botids** - a list of bot (USDT multipair) id's to use. (can also be using BUSD)
+-   **btc-botids** -  a list of bot (BTC multipair) id's to use.
 -   **numberofpairs** - number of pairs to update your bots with. (default is 10)
 -   **accountmode** - trading account mode for the API to use (real or paper). (default is paper)
 -   **3c-apikey** - Your 3Commas API key value.

--- a/watchlist.py
+++ b/watchlist.py
@@ -197,8 +197,8 @@ def load_config():
         "timezone": "Europe/Amsterdam",
         "debug": False,
         "logrotate": 7,
-        "usdt-botid": 0,
-        "btc-botid": 0,
+        "usdt-botids": [12345, 67890],
+        "btc-botids": [12345, 67890],
         "accountmode": "paper",
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
@@ -496,35 +496,36 @@ async def callback(event):
             logger.debug(f"Trade type '{trade}' is not supported yet!")
             return
         if base == "USDT":
-            botid = config.get("settings", "usdt-botid")
-            if botid == 0:
+            botids = json.loads(config.get("settings", "usdt-botids"))
+            if len(botids) == 0:
                 logger.debug(
-                    "No valid botid defined for '%s' in config, disabled." % base
+                    "No valid botids defined for '%s' in config, disabled." % base
                 )
                 return
         elif base == "BTC":
-            botid = config.get("settings", "btc-botid")
-            if botid == 0:
+            botids = json.loads(config.get("settings", "btc-botids"))
+            if len(botids) == 0:
                 logger.debug(
-                    "No valid botid defined for '%s' in config, disabled." % base
+                    "No valid botids defined for '%s' in config, disabled." % base
                 )
                 return
         else:
             logger.error("Error the base of pair '%s' is not supported yet!" % pair)
             return
 
-        error, data = api.request(
-            entity="bots",
-            action="show",
-            action_id=str(botid),
-        )
+        for bot in botids:
+	        error, data = api.request(
+		        entity="bots",
+		        action="show",
+		        action_id=str(bot),
+	        )
 
-        if data:
-            await client.loop.run_in_executor(
-                None, check_pair, data, exchange, base, coin
-            )
-        else:
-            logger.error("Error occurred triggering bot: %s" % error["msg"])
+	        if data:
+		        await client.loop.run_in_executor(
+			        None, check_pair, data, exchange, base, coin
+		        )
+	        else:
+		        logger.error("Error occurred triggering bot: %s" % error["msg"])
     else:
         logger.info("Not a crypto trigger message, or exchange not yet supported.")
 


### PR DESCRIPTION
Watchlist could only work with one USDT and BTC bot, which is sufficient if you are trading on a single exchange. When trading on multiple exchanges, multiple bots can be running. Now this script has the option to update multiple bots running on different exchanges.