### PR TITLE
Use datadir also for Telegram session file

### DIFF
--- a/watchlist.py
+++ b/watchlist.py
@@ -467,7 +467,7 @@ api = init_threecommas_api(config)
 
 # Watchlist telegram trigger
 client = TelegramClient(
-    program,
+    f"{datadir}/{program}",
     config.get("settings", "tgram-api-id"),
     config.get("settings", "tgram-api-hash"),
 ).start(config.get("settings", "tgram-phone-number"))


### PR DESCRIPTION
The 'watchlist.session' was created in the program directory in docker, which is not the same as the datadir. This caused me some trouble to figure out, and it seems logical to store the session file also in the datadir.