### PR TITLE
Fixed shifting end number when start number > 1 and improved notification

### DIFF
--- a/coinmarketcap.py
+++ b/coinmarketcap.py
@@ -224,4 +224,3 @@ while True:
 
     if not wait_time_interval(logger, notification, timeint):
         break
-

--- a/helpers/misc.py
+++ b/helpers/misc.py
@@ -1,6 +1,6 @@
 """Cyberjunky's 3Commas bot helpers."""
-import requests
 import time
+import requests
 
 def wait_time_interval(logger, notification, time_interval):
     """Wait for time interval."""
@@ -92,10 +92,13 @@ def get_coinmarketcap_data(logger, config):
 
     cmcdict = {}
 
+    startnumber = int(config.get("settings", "start-number"))
+    endnumber = 1 + (int(config.get("settings", "end-number")) - startnumber)
+
     # Construct query for CoinMarketCap data
     parms = {
-        "start": config.get("settings", "start-number"),
-        "limit": config.get("settings", "end-number"),
+        "start": startnumber,
+        "limit": endnumber,
         "convert": "BTC",
         "aux": "cmc_rank",
     }
@@ -129,6 +132,7 @@ def get_coinmarketcap_data(logger, config):
         return {}
 
     logger.info("Fetched CoinMarketCap data OK (%s coins)" % (len(cmcdict)))
+    logger.debug(f"CMC data: {cmcdict}")
 
     return cmcdict
 

--- a/helpers/threecommas.py
+++ b/helpers/threecommas.py
@@ -204,8 +204,8 @@ def set_threecommas_bot_pairs(logger, api, thebot, newpairs):
     if data:
         logger.debug("Bot pairs updated: %s" % data)
         logger.info(
-            "Bot '%s' with id '%s' updated with these pairs:\n%s"
-            % (thebot["name"], thebot["id"], newpairs),
+            "Bot '%s' with id '%s' updated with %d pairs (%s t/m %s)"
+            % (thebot["name"], thebot["id"], len(newpairs), newpairs[0], newpairs[-1]),
             True,
         )
     else:


### PR DESCRIPTION
1) Zag inderdaad dat het end number verschuift wanneer start number > 1. Dit vind ik onlogisch, want je wilt kunnen configureren dat je 10 t/m 100 wilt ophalen en dan niet zelf nog moeten gaan rekenen. Ik heb de code nu zodanig aangepast dat ook echt 10 t/m 100 worden opgehaald. 
2) Via apprise wordt een notification gestuurd met de pairs die aan de bot zijn toegevoegd. Voor 100 a 200 pairs is dat nog leuk, maar mocht je ooit een bot voorzien van 2500 pairs...mwah. En mogelijk is de tekst ook te lang en krijg je een foutmelding. De melding heb ik nu aangepast naar dat je het aantal (getal) pairs krijgt wat in de bot is gezet, en de eerste en laatste uit die lijst.