### PR TITLE
Rounding improvement and sleep to prevent 429 error

### DIFF
--- a/compound.py
+++ b/compound.py
@@ -564,5 +564,10 @@ while True:
             else:
                 logger.error("Error occurred updating bots")
 
+        # 3C could return an error code (like 429), however Py3CW does not handle this currently.
+        # Easiest 'fix' is a short sleep of 0.5 seconds and hope it will be enough until this
+        # has been implemented in the Py3CW library
+        time.sleep(0.5)
+
     if not wait_time_interval(logger, notification, timeint):
         break

--- a/helpers/misc.py
+++ b/helpers/misc.py
@@ -157,3 +157,17 @@ def format_pair(logger, marketcode, base, coin):
     logger.debug("New pair constructed: %s" % pair)
 
     return pair
+
+
+def get_round_digits(pair):
+    """Get the number of digits for the round function."""
+
+    numberofdigits = 4
+
+    if pair:
+        base = pair.split("_")[0]
+
+        if base in ("BTC", "ETH"):
+            numberofdigits = 8
+
+    return numberofdigits

--- a/tpincrement.py
+++ b/tpincrement.py
@@ -257,5 +257,10 @@ while True:
             else:
                 logger.error("Error occurred updating bots")
 
+        # 3C could return an error code (like 429), however Py3CW does not handle this currently.
+        # Easiest 'fix' is a short sleep of 0.5 seconds and hope it will be enough until this
+        # has been implemented in the Py3CW library
+        time.sleep(0.5)
+
     if not wait_time_interval(logger, notification, timeint):
         break

--- a/trailingstoploss.py
+++ b/trailingstoploss.py
@@ -281,5 +281,10 @@ while True:
             else:
                 logger.error("Error occurred updating bots")
 
+        # 3C could return an error code (like 429), however Py3CW does not handle this currently.
+        # Easiest 'fix' is a short sleep of 0.5 seconds and hope it will be enough until this
+        # has been implemented in the Py3CW library
+        time.sleep(0.5)
+
     if not wait_time_interval(logger, notification, timeint):
         break


### PR DESCRIPTION
ETH should also be logged with 8 digits, same as BTC, in compound.py. And as we discussed on Discord; protection againt 429 error is not handled in Py3CW lib so added a simple sleep in the hope it will do. Tried to judge and added the sleep to scripts working with deals, as it seems to more intensive ones.