### PR TITLE
Use own function to remove prefix for Python < 3.9

### DIFF
--- a/compound.py
+++ b/compound.py
@@ -11,7 +11,7 @@ import time
 from pathlib import Path
 
 from helpers.logging import Logger, NotificationHandler
-from helpers.misc import check_deal, get_round_digits, wait_time_interval
+from helpers.misc import check_deal, get_round_digits, remove_prefix, wait_time_interval
 from helpers.threecommas import get_threecommas_deals, init_threecommas_api
 
 
@@ -567,7 +567,7 @@ while True:
     for section in config.sections():
         # Each section is a bot
         if section.startswith("bot_"):
-            botid = section.removeprefix("bot_")
+            botid = remove_prefix(section, "bot_")
 
             if botid:
                 boterror, botdata = api.request(

--- a/helpers/misc.py
+++ b/helpers/misc.py
@@ -171,3 +171,11 @@ def get_round_digits(pair):
             numberofdigits = 8
 
     return numberofdigits
+
+
+def remove_prefix(text, prefix):
+    """Get the string without prefix, required for Python < 3.9."""
+
+    if text.startswith(prefix):
+        return text[len(prefix):]
+    return text


### PR DESCRIPTION
Requirement is Python 3.7, and I used a function specific for 3.9 in a previous commit. So, had to be repaired.