### PR TITLE
Added order to ensure the latest deals are picked up

### DIFF
--- a/helpers/threecommas.py
+++ b/helpers/threecommas.py
@@ -381,6 +381,7 @@ def get_threecommas_deals(logger, api, botid):
             "scope": "finished",
             "bot_id": str(botid),
             "limit": 100,
+            "order": "closed_at",
         },
     )
     if error:


### PR DESCRIPTION
I noticed that for my USDT bot, the latest deal was not picked up for some reason.
Running the exact API call with PostMan, also did not pick up the latest deal.
I've added the "order" parameter to the deal-fetch, to ensure that it orders by latest deals, as described at https://github.com/3commas-io/3commas-official-api-docs/blob/master/deals_api.md#user-deals-permission-bots_read-security-signed

This ensured that the deal was picked up properly.