### PR TITLE
Ability to share exclude pairs between scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ If this is the case -and the current pairs are different than the current ones- 
 
 After this the bot helper will sleep for the set interval time, after which it will repeat these steps.
 
+When the SHAREDIR option is used, this script will try to read a `.pairexclude` file for each configured bot. If a pair is listed in the file it will be excluded from the pairs before updating the bot. This can be usefull when also using the DealCluster script in parallel with this script.
+
 NOTE: make sure you specify a 'Trading 24h minimal volume' value in your bot(s), otherwise you can end up with 'shitcoins'. Check the LunarCrush website or galaxyscore.log file after running in debug mode for a while to see which coins and values are retrieved, and decide how much risk you want to take.
 
 ### Configuration
@@ -168,6 +170,8 @@ It will monitor LunarCrush's AltRank list and use the Top X to create pairs for 
 ### How does it work?
 
 Same as galaxyscore bot helper except with AltRank data.
+
+When the SHAREDIR option is used, this script will try to read a `.pairexclude` file for each configured bot. If a pair is listed in the file it will be excluded from the pairs before updating the bot. This can be usefull when also using the DealCluster script in parallel with this script.
 
 NOTE: make sure you specify a 'Trading 24h minimal volume' value in your bot(s), otherwise you can end up with 'shitcoins'. Check the LunarCrush website or altrank.log file after running in debug mode for a while to see which coins and values are retrieved, and decide how much risk you want to take.
 
@@ -224,7 +228,9 @@ If this is the case -and the current pairs are different than the current ones- 
 
 After this the bot helper will sleep for the set interval time, after which it will repeat these steps.
 
-This script can be used for multiple bots with different Top X coins by creating multiple `cmc_` sections in the configuration file. For each section CMC data is fetched and processed as described above. Make sure each section starts with `cmc_` between the square brackets, what follows does not matter and can be used to give a descriptive name for yourself. 
+This script can be used for multiple bots with different Top X coins by creating multiple `cmc_` sections in the configuration file. For each section CMC data is fetched and processed as described above. Make sure each section starts with `cmc_` between the square brackets, what follows does not matter and can be used to give a descriptive name for yourself.
+
+When the SHAREDIR option is used, this script will try to read a `.pairexclude` file for each configured bot. If a pair is listed in the file it will be excluded from the pairs before updating the bot. This can be usefull when also using the DealCluster script in parallel with this script.
 
 NOTE: the 'Trading 24h minimal volume' value in your bot(s) can be used to prevent deals with low volume. Random pairs can be excluded using the blacklist. The first top coins (like BTC and ETH) can also be excluded by increasing the start-number.
 
@@ -291,7 +297,9 @@ If this is the case -and the current pairs are different than the current ones- 
 
 After this the bot helper will sleep for the set interval time, after which it will repeat these steps.
 
-This script can be used for multiple bots with different Top X lists by creating multiple `botassist_` sections in the configuration file. For each section bot-assist data is fetched and processed as described above. Make sure each section starts with `botassist_` between the square brackets, what follows does not matter and can be used to give a descriptive name for yourself. 
+This script can be used for multiple bots with different Top X lists by creating multiple `botassist_` sections in the configuration file. For each section bot-assist data is fetched and processed as described above. Make sure each section starts with `botassist_` between the square brackets, what follows does not matter and can be used to give a descriptive name for yourself.
+
+When the SHAREDIR option is used, this script will try to read a `.pairexclude` file for each configured bot. If a pair is listed in the file it will be excluded from the pairs before updating the bot. This can be usefull when also using the DealCluster script in parallel with this script.
 
 NOTE: the 'Trading 24h minimal volume' value in your bot(s) can be used to prevent deals with low volume. Random pairs can be excluded using the blacklist. The first top pairs (like BTC and ETH) can also be excluded by increasing the start-number.
 
@@ -774,6 +782,8 @@ Once a deal is gone and the number of deals for this pair is below `max-same-dea
 
 Notice you can create more than one cluster as long as each section starts with 'cluster_'. The example configuration below contains a single 'default' cluster.
 
+When the SHAREDIR option is used, this script will create a `.pairexclude` file for each bot within a configured cluster. This file contains the pairs which have been disabled and can be used by other scripts to prevent enabling these pairs and triggering new deals, making this script ineffective.
+
 Note: sometimes 3C deals can be opened within seconds and there is nothing this script can do to prevent it. Shorter intervals will decrease this possibility, but also beware 3C has a rate limit so do not go that low (the author used a minimum of 120 seconds).
 
 
@@ -957,7 +967,7 @@ They also have some command-line options:
 
 ```
 ./galaxyscore.py -h
-usage: galaxyscore.py [-h] [-d DATADIR] [-b BLACKLIST]
+usage: galaxyscore.py [-h] [-d DATADIR] [-s SHAREDIR] [-b BLACKLIST]
 
 Cyberjunky's 3Commas bot helper.
 
@@ -965,6 +975,8 @@ optional arguments:
   -h, --help            show this help message and exit
   -d DATADIR, --datadir DATADIR
                         directory to use for config and logs files
+  -s SHAREDIR, --sharedir SHAREDIR
+                        directory to use for shared files between scripts
   -b BLACKLIST, --blacklist BLACKLIST
                         local blacklist to use instead of 3Commas's
 ```

--- a/altrank.py
+++ b/altrank.py
@@ -13,6 +13,7 @@ from helpers.misc import (
     format_pair,
     get_lunarcrush_data,
     populate_pair_lists,
+    remove_excluded_pairs,
     wait_time_interval,
 )
 from helpers.threecommas import (
@@ -154,6 +155,10 @@ def lunarcrush_pairs(thebot):
         "These pairs are invalid on '%s' and were skipped: %s" % (marketcode, badpairs)
     )
 
+    # If sharedir is set, other scripts could provide a file with pairs to exclude
+    if sharedir is not None:
+        remove_excluded_pairs(logger, sharedir, thebot['id'], newpairs)
+
     if not newpairs:
         logger.info(
             "None of the LunarCrush pairs are present on the %s (%s) exchange!"
@@ -174,6 +179,9 @@ parser.add_argument(
     "-d", "--datadir", help="directory to use for config and logs files", type=str
 )
 parser.add_argument(
+    "-s", "--sharedir", help="directory to use for shared files", type=str
+)
+parser.add_argument(
     "-b", "--blacklist", help="local blacklist to use instead of 3Commas's", type=str
 )
 
@@ -182,6 +190,12 @@ if args.datadir:
     datadir = args.datadir
 else:
     datadir = os.getcwd()
+
+# pylint: disable-msg=C0103
+if args.sharedir:
+    sharedir = args.sharedir
+else:
+    sharedir = None
 
 # pylint: disable-msg=C0103
 if args.blacklist:

--- a/botassistexplorer.py
+++ b/botassistexplorer.py
@@ -10,9 +10,9 @@ from pathlib import Path
 
 from helpers.logging import Logger, NotificationHandler
 from helpers.misc import (
-    format_pair,
     get_botassist_data,
     populate_pair_lists,
+    remove_excluded_pairs,
     wait_time_interval,
 )
 from helpers.threecommas import (
@@ -89,6 +89,10 @@ def botassist_pairs(thebot, botassistdata):
         "These pairs are invalid on '%s' and were skipped: %s" % (marketcode, badpairs)
     )
 
+    # If sharedir is set, other scripts could provide a file with pairs to exclude
+    if sharedir is not None:
+        remove_excluded_pairs(logger, sharedir, thebot['id'], newpairs)
+
     if not newpairs:
         logger.info(
             "None of the by 3c-tools bot-assist suggested pairs have been found on the %s (%s) exchange!"
@@ -109,6 +113,9 @@ parser.add_argument(
     "-d", "--datadir", help="directory to use for config and logs files", type=str
 )
 parser.add_argument(
+    "-s", "--sharedir", help="directory to use for shared files", type=str
+)
+parser.add_argument(
     "-b", "--blacklist", help="local blacklist to use instead of 3Commas's", type=str
 )
 
@@ -117,6 +124,12 @@ if args.datadir:
     datadir = args.datadir
 else:
     datadir = os.getcwd()
+
+# pylint: disable-msg=C0103
+if args.sharedir:
+    sharedir = args.sharedir
+else:
+    sharedir = None
 
 # pylint: disable-msg=C0103
 if args.blacklist:

--- a/coinmarketcap.py
+++ b/coinmarketcap.py
@@ -13,6 +13,7 @@ from helpers.misc import (
     format_pair,
     get_coinmarketcap_data,
     populate_pair_lists,
+    remove_excluded_pairs,
     wait_time_interval,
 )
 from helpers.threecommas import (
@@ -146,6 +147,10 @@ def coinmarketcap_pairs(thebot, cmcdata):
         "These pairs are invalid on '%s' and were skipped: %s" % (marketcode, badpairs)
     )
 
+    # If sharedir is set, other scripts could provide a file with pairs to exclude
+    if sharedir is not None:
+        remove_excluded_pairs(logger, sharedir, thebot['id'], newpairs)
+
     if not newpairs:
         logger.info(
             "None of the by CoinMarketCap suggested pairs have been found on the %s (%s) exchange!"
@@ -166,6 +171,9 @@ parser.add_argument(
     "-d", "--datadir", help="directory to use for config and logs files", type=str
 )
 parser.add_argument(
+    "-s", "--sharedir", help="directory to use for shared files", type=str
+)
+parser.add_argument(
     "-b", "--blacklist", help="local blacklist to use instead of 3Commas's", type=str
 )
 
@@ -174,6 +182,12 @@ if args.datadir:
     datadir = args.datadir
 else:
     datadir = os.getcwd()
+
+# pylint: disable-msg=C0103
+if args.sharedir:
+    sharedir = args.sharedir
+else:
+    sharedir = None
 
 # pylint: disable-msg=C0103
 if args.blacklist:

--- a/constants/pair.py
+++ b/constants/pair.py
@@ -1,0 +1,5 @@
+"""Cyberjunky's 3Commas bot helpers."""
+from typing import Final
+
+
+PAIREXCLUDE_EXT: Final = "pairexclude"

--- a/dealcluster.py
+++ b/dealcluster.py
@@ -8,6 +8,7 @@ import sqlite3
 import sys
 import time
 from pathlib import Path
+from constants.pair import PAIREXCLUDE_EXT
 
 from helpers.logging import Logger, NotificationHandler
 from helpers.misc import check_deal, wait_time_interval
@@ -341,19 +342,47 @@ def update_bot_pairs(cluster_id, thebot):
 
     # Here rowid is used which is not defined in the init() function. Rowid
     # is a default column in SQLite when using an INT as primary key
-    botpairs = cursor.execute(
+    botenabledpairs = cursor.execute(
         f"SELECT pair FROM bot_pairs "
         f"WHERE clusterid = '{cluster_id}' AND botid = {bot_id} AND enabled = {1} "
         f"ORDER BY rowid ASC"
     ).fetchall()
 
-    if botpairs:
-        pairlist = [row[0] for row in botpairs]
-        set_threecommas_bot_pairs(logger, api, thebot, pairlist, False)
+    if botenabledpairs:
+        enabledpairlist = [row[0] for row in botenabledpairs]
+        set_threecommas_bot_pairs(logger, api, thebot, enabledpairlist, False)
     else:
         logger.warning(
-            f"Failed to get bot pairs for bot {bot_id}"
+            f"Failed to get enabled pairs for bot {bot_id}"
         )
+
+    if sharedir is not None:
+        botdisabledpairs = cursor.execute(
+            f"SELECT pair FROM bot_pairs "
+            f"WHERE clusterid = '{cluster_id}' AND botid = {bot_id} AND enabled = {0}"
+        ).fetchall()
+
+        if botdisabledpairs:
+            disabledpairlist = [row[0] for row in botdisabledpairs]
+            write_bot_exclude_file(bot_id, disabledpairlist)
+        else:
+            logger.warning(
+                f"Failed to get disabled pairs for bot {bot_id}"
+            )
+
+
+def write_bot_exclude_file(bot_id, pairs):
+    """Write the exclude file for the specified bot"""
+
+    excludefilename = f"{sharedir}/{bot_id}.{PAIREXCLUDE_EXT}"
+
+    logger.info(
+        f"Writing pairs {pairs} to file {excludefilename}"
+    )
+
+    with open(excludefilename, 'w') as filehandle:
+        for pair in pairs:
+            filehandle.write('%s\n' % pair)
 
 
 # Start application
@@ -365,6 +394,9 @@ parser.add_argument(
     "-d", "--datadir", help="directory to use for config and logs files", type=str
 )
 parser.add_argument(
+    "-s", "--sharedir", help="directory to use for shared files", type=str
+)
+parser.add_argument(
     "-b", "--blacklist", help="local blacklist to use instead of 3Commas's", type=str
 )
 
@@ -373,6 +405,12 @@ if args.datadir:
     datadir = args.datadir
 else:
     datadir = os.getcwd()
+
+# pylint: disable-msg=C0103
+if args.sharedir:
+    sharedir = args.sharedir
+else:
+    sharedir = None
 
 # pylint: disable-msg=C0103
 if args.blacklist:

--- a/galaxyscore.py
+++ b/galaxyscore.py
@@ -13,6 +13,7 @@ from helpers.misc import (
     format_pair,
     get_lunarcrush_data,
     populate_pair_lists,
+    remove_excluded_pairs,
     wait_time_interval,
 )
 from helpers.threecommas import (
@@ -154,6 +155,10 @@ def lunarcrush_pairs(thebot):
         "These pairs are invalid on '%s' and were skipped: %s" % (marketcode, badpairs)
     )
 
+    # If sharedir is set, other scripts could provide a file with pairs to exclude
+    if sharedir is not None:
+        remove_excluded_pairs(logger, sharedir, thebot['id'], newpairs)
+
     if not newpairs:
         logger.info(
             "None of the LunarCrush pairs are present on the %s (%s) exchange!"
@@ -174,6 +179,9 @@ parser.add_argument(
     "-d", "--datadir", help="directory to use for config and logs files", type=str
 )
 parser.add_argument(
+    "-s", "--sharedir", help="directory to use for shared files", type=str
+)
+parser.add_argument(
     "-b", "--blacklist", help="local blacklist to use instead of 3Commas's", type=str
 )
 
@@ -182,6 +190,12 @@ if args.datadir:
     datadir = args.datadir
 else:
     datadir = os.getcwd()
+
+# pylint: disable-msg=C0103
+if args.sharedir:
+    sharedir = args.sharedir
+else:
+    sharedir = None
 
 # pylint: disable-msg=C0103
 if args.blacklist:

--- a/helpers/misc.py
+++ b/helpers/misc.py
@@ -4,6 +4,8 @@ import time
 import requests
 from bs4 import BeautifulSoup
 
+from constants.pair import PAIREXCLUDE_EXT
+
 
 def wait_time_interval(logger, notification, time_interval, notify=True):
     """Wait for time interval."""
@@ -220,3 +222,40 @@ def get_botassist_data(logger, botassistlist, start_number, limit):
     logger.info("Fetched 3c-tools bot-assist data OK (%s pairs)" % (len(pairs)))
 
     return pairs
+
+
+def remove_excluded_pairs(logger, share_dir, bot_id, newpairs):
+    """Remove pairs which are excluded by other script(s)."""
+
+    excludedpairs = load_bot_excluded_pairs(logger, share_dir, bot_id, PAIREXCLUDE_EXT)
+    if excludedpairs:
+        logger.info(
+            f"Removing the following pair(s) for bot {bot_id}: {excludedpairs}"
+        )
+
+        for pair in excludedpairs:
+            if newpairs.count(pair) > 0:
+                newpairs.remove(pair)
+
+
+def load_bot_excluded_pairs(logger, share_dir, bot_id, extension):
+    """Load excluded pairs from file, for the specified bot"""
+
+    excludedlist = []
+    excludefilename = f"{share_dir}/{bot_id}.{extension}"
+
+    try:
+        with open(excludefilename, "r") as file:
+            excludedlist = file.read().splitlines()
+        if excludedlist:
+            logger.info(
+                "Reading exclude file '%s' OK (%s pairs)"
+                % (excludefilename, len(excludedlist))
+            )
+    except FileNotFoundError:
+        logger.info(
+            "Exclude file (%s) not found for bot '%s'; no pairs to exclude."
+            % (excludefilename, bot_id)
+        )
+
+    return excludedlist


### PR DESCRIPTION
DealCluster can disable pairs in a bot, while other scripts can update the bot and enable those pairs. So, these changes make it possible to share the excluded pairs between scripts so they can remove those pairs before updating the bot(s).