### PR TITLE
Support short deals in trailingstoploss_tp script

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ Type = stop loss
 
 ### What does it do?
 
-It will change the trailing stoploss (and optionally the profit %) of a DCA bot when the profit % >= as the activation-percentage setting.
+It will change the trailing stoploss (and optionally the profit %) of a DCA deal when the profit % is above the activation-percentage setting. Works for both long and short deals.
 
 ### How does it work?
 


### PR DESCRIPTION
Only longs where working before, now also short deals are working! Made sure the deals are processed by the same functions, only the calculations for short vs long are different.