### PR TITLE
Advanced trialingstoploss_tp and dealcluster operating on coins

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ The take profit can also be increased using the `tp-increment-factor` and the ca
 
 Configuring the `tp-increment-factor` to 0.0 will disable the increment and leave the TP untouched to what is configured in the bot.
 
-Do note that extra profit is directly included! So, for example, when the `activation-percentage` is set to 3.0% and the `actual profit` is 3.2%, this 0.2% is immediately added to the `initial-stoploss`.
+Do note that extra profit is directly included if the `increment-factor` is greater than 0.0! So, for example, when the `activation-percentage` is set to 3.0% and the `actual profit` is 3.2%, this 0.2% is immediately added to the `initial-stoploss`.
 
 The last profit percentage of the deal is stored to be used for next iterations, so the bot only evaluates deals for which the % profit has increased to avoid unnecessary processing. In the calcutions shown above the `current` and `last` profit percentage will then be used.
 
@@ -464,7 +464,18 @@ Then the bot helper will sleep for the set interval time, after which it will re
 
 This script can be used for multiple bots with different TSL and TP settings by creating multiple tsl_tp_ sections in the configuration file. Each section is processed as described above. Make sure each section starts with tsl_tp_ between the square brackets, what follows does not matter and can be used to give a descriptive name for yourself.
 
-Note: the percentages used can be confusing. Please read the following document to understand them better: [in-depth](docs/trailingstoploss_tp-in-depth.pdf)
+### Advanced configuration
+This script supports some advanced configuration which should be understood! The basic purpose is to provide a trailing stoploss and optionally increasing take profit. When a deal starts to make profit the price will go up and down and therefor some space should be available to do so. So, for example, at 2% the SL can be set around 0.5% so the 1.5% can be used to go up and down. When the profit increases, for example to 4%, you may want to set the SL to 3% to avoid missing some profit (otherwise the SL would still be around 2%, depending on the `sl-increment-factor`). And sometimes, you just want to prevent a deal going down and rather have a fixed SL at a certain percentage.
+
+The great thing is; this is all possible with this script. The `config` of each section can contain one or more configurations which will be used. Make sure the configuration are in order, increasing in `activation-percentage`! As example:
+- The first configuration could have a lower `activation-percentage` of 2.0%, an `initial-stoploss-percentage` of 0.5% and the `increment-factors` are set to 0.0 (disabled).
+- The second configuration could have a `activation-percentage` of 3.0%, an `initial-stoploss-percentage` of 2.0% and the `increment-factors` are greater than 0.0 (enabled).
+This will result in a fixed SL of 0.5% when the profit reaches 2.0%. Even when the price or market dumps, you don't end up with a red bag because of this SL. Between 2.0% and the 3.0%, the SL remains untouched. As soon as the profit reaches the 3.0%, the second configuration will be used and the SL is directly set to 2.0%; and from there the trailing starts. 
+
+See the configuration below as an example on how to do this.
+
+### In depth
+The percentages and how the stoploss works at 3C can be confusing. Please read the following document to understand this better: [in-depth](docs/trailingstoploss_tp-in-depth.pdf)
 
 
 Author of this script is [amargedon](https://github.com/amargedon).
@@ -484,11 +495,13 @@ This is the layout of the config file used by the `trailingstoploss_tp.py` bot h
 -   **notifications** - set to true to enable notifications. (default = False)
 -   **notify-urls** - one or a list of apprise notify urls, each in " " seperated with commas. See [Apprise website](https://github.com/caronc/apprise) for more information.
 -   *[tsl_tp_]*
--   **botids** - a list of bot id's to manage separated with commas
--   **activation-percentage** - % of profit at which script becomes active for a bot. (default = 3.0)
--   **initial-stoploss-percentage** - % of stoploss to start on when activation-percentage is reached. (default = 1.0)
--   **sl-increment-factor** - % to increase the SL with, based on % profit after activation-percentage. (default = 0.5)
--   **tp-increment-factor** - % to increase the TP with, based on % profit after activation-percentage. (default = 0.5)
+-   **botids** - a list of bot id's to manage separated with commas.
+-   **config** - a list of objects with the settings for that percentage.
+-   *object*
+-   **activation-percentage** - from % of profit this object is valid for.
+-   **initial-stoploss-percentage** - % of stoploss to set when activation-percentage is reached.
+-   **sl-increment-factor** - % to increase the SL with, based on % profit after activation-percentage.
+-   **tp-increment-factor** - % to increase the TP with, based on % profit after activation-percentage.
 
 Example: (keys are bogus)
 ```
@@ -505,10 +518,8 @@ notify-urls = [ "tgram://9995888120:BoJPor6opeHyxx5VVZPX-BoJPor6opeHyxx5VVZPX/" 
 
 [tsl_tp_default]
 botids = [ 123456 ]
-activation-percentage = 3.0
-initial-stoploss-percentage = 1.0
-sl-increment-factor = 0.5
-tp-increment-factor = 0.5
+config = [{"activation-percentage": "2.0","initial-stoploss-percentage": "0.5","sl-increment-factor": "0.0","tp-increment-factor": "0.0"},{"activation-percentage": "3.0","initial-stoploss-percentage": "2.0","sl-increment-factor": "0.4","tp-increment-factor": "0.4"}]
+
 ```
 
 ### Example output

--- a/altrank.py
+++ b/altrank.py
@@ -216,7 +216,7 @@ def lunarcrush_pairs(cfg, thebot):
 
     # If sharedir is set, other scripts could provide a file with pairs to exclude
     if sharedir is not None:
-        remove_excluded_pairs(logger, sharedir, thebot["id"], newpairs)
+        remove_excluded_pairs(logger, sharedir, thebot['id'], marketcode, base, newpairs)
 
     if not newpairs:
         logger.info(
@@ -225,7 +225,8 @@ def lunarcrush_pairs(cfg, thebot):
         )
         return
 
-    # Lower the number of max deals if not enough new pairs and change allowed, change back to original if possible
+    # Lower the number of max deals if not enough new pairs and change allowed and
+    # change back to original if possible
     if allowmaxdealchange:
         if len(newpairs) < thebot["max_active_deals"]:
             newmaxdeals = len(newpairs)

--- a/botassistexplorer.py
+++ b/botassistexplorer.py
@@ -91,7 +91,7 @@ def botassist_pairs(thebot, botassistdata):
 
     # If sharedir is set, other scripts could provide a file with pairs to exclude
     if sharedir is not None:
-        remove_excluded_pairs(logger, sharedir, thebot['id'], newpairs)
+        remove_excluded_pairs(logger, sharedir, thebot['id'], marketcode, base, newpairs)
 
     if not newpairs:
         logger.info(

--- a/coinmarketcap.py
+++ b/coinmarketcap.py
@@ -149,7 +149,7 @@ def coinmarketcap_pairs(thebot, cmcdata):
 
     # If sharedir is set, other scripts could provide a file with pairs to exclude
     if sharedir is not None:
-        remove_excluded_pairs(logger, sharedir, thebot['id'], newpairs)
+        remove_excluded_pairs(logger, sharedir, thebot['id'], marketcode, base, newpairs)
 
     if not newpairs:
         logger.info(

--- a/dealcluster.py
+++ b/dealcluster.py
@@ -52,7 +52,7 @@ def upgrade_config(thelogger, cfg):
     return cfg
 
 
-def init_coin_db():
+def init_cluster_db():
     """Create or open database to store cluster and coin data."""
     try:
         dbname = f"{program}.sqlite3"
@@ -69,21 +69,31 @@ def init_coin_db():
         logger.info(f"Database '{datadir}/{dbname}' created successfully")
 
         dbcursor.execute(
-            "CREATE TABLE deals (dealid INT Primary Key, pair STRING, clusterid STRING, "
-            "botid INT, active BIT)"
+            "CREATE TABLE IF NOT EXISTS deals ("
+            "dealid INT Primary Key, "
+            "coin STRING, "
+            "clusterid STRING, "
+            "botid INT, "
+            "active BIT"
+            ")"
         )
 
         dbcursor.execute(
-            "CREATE TABLE cluster_pairs (clusterid STRING, pair STRING, number_active INT, "
-            "PRIMARY KEY(clusterid, pair))"
+            "CREATE TABLE IF NOT EXISTS cluster_coins ("
+            "clusterid STRING, "
+            "coin STRING, "
+            "number_active INT, "
+            "PRIMARY KEY(clusterid, coin)"
+            ")"
         )
 
         dbcursor.execute(
-            "CREATE TABLE bot_pairs ("
+            "CREATE TABLE IF NOT EXISTS bot_pairs ("
             "clusterid STRING, "
             "botid INT, "
             "botname STRING, "
             "pair STRING, "
+            "coin STRING, "
             "enabled BIT, "
             "PRIMARY KEY(clusterid, botid, pair)"
             ")"
@@ -92,6 +102,35 @@ def init_coin_db():
         logger.info("Database tables created successfully")
 
     return dbconnection
+
+
+def upgrade_cluster_db():
+    """Upgrade database if needed."""
+
+    try:
+        try:
+            # DROP column supported from sqlite 3.35.0 (2021.03.12)
+            cursor.execute("ALTER TABLE deals DROP COLUMN pair")
+        except sqlite3.OperationalError:
+            logger.debug("Older SQLite version; not used columns not removed")
+
+        cursor.execute("ALTER TABLE deals ADD COLUMN coin STRING")
+
+        cursor.execute("DROP TABLE cluster_pairs")
+        cursor.execute(
+            "CREATE TABLE IF NOT EXISTS cluster_coins ("
+            "clusterid STRING, "
+            "coin STRING, "
+            "number_active INT, "
+            "PRIMARY KEY(clusterid, coin)"
+            ")"
+        )
+
+        cursor.execute("ALTER TABLE bot_pairs ADD COLUMN coin STRING")
+
+        logger.info("Database schema upgraded (pair to coins)")
+    except sqlite3.OperationalError:
+        logger.debug("Database schema is up-to-date")
 
 
 def clean_bot_db_data(thebot):
@@ -126,11 +165,11 @@ def process_bot_deals(cluster_id, thebot):
 
             existing_deal = check_deal(cursor, deal_id)
             if not existing_deal:
-                deal_pair = deal['pair']
+                deal_coin = deal['pair'].split("_")[1]
 
                 db.execute(
-                    f"INSERT INTO deals (dealid, pair, clusterid, botid, active) "
-                    f"VALUES ({deal_id}, '{deal_pair}', '{cluster_id}', {bot_id}, {1})"
+                    f"INSERT INTO deals (dealid, coin, clusterid, botid, active) "
+                    f"VALUES ({deal_id}, '{deal_coin}', '{cluster_id}', {bot_id}, {1})"
                 )
                 logger.info(
                     f"New deal found {deal_id}/{deal['pair']} on bot \"{thebot['name']}",
@@ -173,8 +212,12 @@ def process_bot_deals(cluster_id, thebot):
 
         for pair in botpairs:
             db.execute(
-                f"INSERT OR IGNORE INTO bot_pairs (clusterid, botid, botname, pair, enabled) "
-                f"VALUES ('{cluster_id}', {bot_id},'{botname}', '{pair}', {1})"
+                f"INSERT OR IGNORE INTO bot_pairs ("
+                f"clusterid, botid, botname, pair, coin, enabled"
+                f") "
+                f"VALUES ("
+                f"'{cluster_id}', {bot_id},'{botname}', '{pair}', '{pair.split('_')[1]}', {1}"
+                f")"
             )
 
     db.commit()
@@ -184,7 +227,7 @@ def log_deals(cluster_id):
     """Log the deals within this cluster"""
 
     dealdata = cursor.execute(
-        f"SELECT dealid, pair, botid, active FROM deals "
+        f"SELECT dealid, pair, coin, botid, active FROM deals "
         f"WHERE clusterid = '{cluster_id}'"
     ).fetchall()
 
@@ -192,7 +235,7 @@ def log_deals(cluster_id):
         logger.info(f"Printing deals for '{cluster_id}':")
         for entry in dealdata:
             logger.info(
-                f"{entry[0]}: {entry[1]}, {entry[2]} => {entry[3]}"
+                f"{entry[0]}: {entry[1]} ({entry[2]}), {entry[3]} => {entry[4]}"
             )
     else:
         logger.info(
@@ -207,18 +250,18 @@ def aggregrate_cluster(cluster_id):
 
     # Remove old data
     db.execute(
-        f"DELETE from cluster_pairs WHERE clusterid = '{cluster_id}'"
+        f"DELETE from cluster_coins WHERE clusterid = '{cluster_id}'"
     )
 
-    # Create the cluster data, how many of the same pairs are active within the
+    # Create the cluster data, how many of the same coins are active within the
     # cluster based on the active deals
     db.execute(
-        f"INSERT INTO cluster_pairs (clusterid, pair, number_active) "
-        f"SELECT clusterid, pair, "
+        f"INSERT INTO cluster_coins (clusterid, coin, number_active) "
+        f"SELECT clusterid, coin, "
         f"SUM ( CASE WHEN active = {1} THEN 1 ELSE 0 END) AS number_active "
         f"FROM deals "
         f"WHERE clusterid = '{cluster_id}' "
-        f"GROUP BY pair"
+        f"GROUP BY coin"
     )
 
     db.commit()
@@ -228,12 +271,12 @@ def log_cluster_data(cluster_id):
     """Log the aggregated data based on the deals for this cluster"""
 
     clusterdata = cursor.execute(
-        f"SELECT clusterid, pair, number_active FROM cluster_pairs "
+        f"SELECT clusterid, coin, number_active FROM cluster_coins "
         f"WHERE clusterid = '{cluster_id}'"
     ).fetchall()
 
     if clusterdata:
-        logger.info(f"Printing cluster_pairs for '{cluster_id}':")
+        logger.info(f"Printing cluster_coins for '{cluster_id}':")
         for entry in clusterdata:
             logger.info(
                 f"{entry[1]}: {entry[2]}"
@@ -249,59 +292,59 @@ def process_cluster_deals(cluster_id):
 
     # Get the cluster data and pair numbers
     clusterdata = db.execute(
-        f"SELECT clusterid, pair, number_active FROM cluster_pairs "
+        f"SELECT clusterid, coin, number_active FROM cluster_coins "
         f"WHERE clusterid = '{cluster_id}'"
     ).fetchall()
 
     if clusterdata:
-        logger.info(f"Processing cluster_pairs for '{cluster_id}':")
+        logger.info(f"Processing cluster_coins for '{cluster_id}':")
 
-        enablepairs = []
-        disablepairs = []
+        enablecoins = []
+        disablecoins = []
 
         for entry in clusterdata:
-            pair = str(entry[1])
+            coin = str(entry[1])
             numberofdeals = int(entry[2])
 
             logger.info(
-                f"Pair {pair} has {numberofdeals} deal(s) active"
+                f"Coin {coin} has {numberofdeals} deal(s) active"
             )
 
             if numberofdeals >= int(config.get(cluster_id, "max-same-deals")):
                 # Found a pair which should be suspended
-                disablepairs.append(pair)
+                disablecoins.append(coin)
 
-                log_disable_enable_pair(cluster_id, pair, 0)
+                log_disable_enable_coin(cluster_id, coin, 0)
             else:
                 # Found a pair which can be activated again
-                enablepairs.append(pair)
+                enablecoins.append(coin)
 
-                log_disable_enable_pair(cluster_id, pair, 1)
+                log_disable_enable_coin(cluster_id, coin, 1)
 
-        # Enable the found pairs (caused by finished deals)
-        if enablepairs:
+        # Enable the found coins (caused by finished deals)
+        if enablecoins:
             # Remove start and end square bracket so we can properly use it
-            enablepairs_str = str(enablepairs)[1:-1]
+            enablecoins_str = str(enablecoins)[1:-1]
 
             logger.info(
-                f"Enabling pairs for {cluster_id}: {enablepairs_str}"
+                f"Enabling coins for {cluster_id}: {enablecoins_str}"
             )
             db.execute(
                 f"UPDATE bot_pairs SET enabled = {1} "
-                f"WHERE clusterid = '{cluster_id}' AND pair IN ({enablepairs_str})"
+                f"WHERE clusterid = '{cluster_id}' AND coin IN ({enablecoins_str})"
             )
 
-        # Disable the found pairs (caused by new deals)
-        if disablepairs:
+        # Disable the found coins (caused by new deals)
+        if disablecoins:
             # Remove start and end square bracket so we can properly use it
-            disablepairs_str = str(disablepairs)[1:-1]
+            disablecoins_str = str(disablecoins)[1:-1]
 
             logger.info(
-                f"Disabling pairs for {cluster_id}: {disablepairs_str}"
+                f"Disabling coins for {cluster_id}: {disablecoins_str}"
             )
             db.execute(
                 f"UPDATE bot_pairs SET enabled = {0} "
-                f"WHERE clusterid = '{cluster_id}' AND pair IN ({disablepairs_str})"
+                f"WHERE clusterid = '{cluster_id}' AND coin IN ({disablecoins_str})"
             )
 
         db.commit()
@@ -311,19 +354,19 @@ def process_cluster_deals(cluster_id):
         )
 
 
-def log_disable_enable_pair(cluster_id, pair, new_enabled_value):
+def log_disable_enable_coin(cluster_id, coin, new_enabled_value):
     """Log the pairs which will be enabled or disabled"""
 
     pairdata = cursor.execute(
-        f"SELECT botid, botname, pair, enabled FROM bot_pairs "
-        f"WHERE clusterid = '{cluster_id}' AND pair = '{pair}'"
+        f"SELECT botid, botname, enabled FROM bot_pairs "
+        f"WHERE clusterid = '{cluster_id}' AND coin = '{coin}'"
     ).fetchall()
 
     if pairdata:
         changedbots = ""
 
         for entry in pairdata:
-            if entry[3] != new_enabled_value:
+            if entry[2] != new_enabled_value:
                 if changedbots:
                     changedbots += ", "
                 changedbots += str(entry[1]) + " (" + str(entry[0]) + ")"
@@ -331,18 +374,18 @@ def log_disable_enable_pair(cluster_id, pair, new_enabled_value):
         if changedbots:
             if new_enabled_value:
                 logger.info(
-                    f"Enabling pair {pair} for the following bot(s): {changedbots}",
+                    f"Enabling coin {coin} for the following bot(s): {changedbots}",
                     True
                 )
             else:
                 logger.info(
-                    f"Disabling pair {pair} for the following bot(s): {changedbots}",
+                    f"Disabling coin {coin} for the following bot(s): {changedbots}",
                     True
                 )
 
 
-def update_bot_pairs(cluster_id, thebot):
-    """Update bots."""
+def update_bot_config(cluster_id, thebot):
+    """Update bots at 3C"""
 
     bot_id = thebot["id"]
 
@@ -362,29 +405,36 @@ def update_bot_pairs(cluster_id, thebot):
             f"Failed to get enabled pairs for bot {bot_id}"
         )
 
+
+def write_cluster_exclude_files(cluster_id, bot_list):
+    """Write exclude files for each bot in the specified cluster"""
+
     if sharedir is not None:
-        botdisabledpairs = cursor.execute(
-            f"SELECT pair FROM bot_pairs "
-            f"WHERE clusterid = '{cluster_id}' AND botid = {bot_id} AND enabled = {0}"
+        clusterdisabledcoins = cursor.execute(
+            f"SELECT coin FROM cluster_coins "
+            f"WHERE clusterid = '{cluster_id}' AND "
+            f"number_active >= {int(config.get(cluster_id, 'max-same-deals'))}"
         ).fetchall()
 
-        if botdisabledpairs:
-            disabledpairlist = [row[0] for row in botdisabledpairs]
-            write_bot_exclude_file(bot_id, disabledpairlist)
+        if clusterdisabledcoins:
+            disabledcoinlist = [row[0] for row in clusterdisabledcoins]
+
+            for botid in bot_list:
+                write_bot_exclude_file(botid, disabledcoinlist)
 
 
-def write_bot_exclude_file(bot_id, pairs):
+def write_bot_exclude_file(bot_id, coins):
     """Write the exclude file for the specified bot"""
 
     excludefilename = f"{sharedir}/{bot_id}.{PAIREXCLUDE_EXT}"
 
     logger.info(
-        f"Writing pairs {pairs} to file {excludefilename}"
+        f"Writing coins {coins} to file {excludefilename}"
     )
 
     with open(excludefilename, 'w') as filehandle:
-        for pair in pairs:
-            filehandle.write('%s\n' % pair)
+        for coin in coins:
+            filehandle.write('%s\n' % coin)
 
 
 # Start application
@@ -463,8 +513,11 @@ else:
 api = init_threecommas_api(config)
 
 # Initialize or open the database
-db = init_coin_db()
+db = init_cluster_db()
 cursor = db.cursor()
+
+# Upgrade the database if needed
+upgrade_cluster_db()
 
 # DCA Deal Cluster
 while True:
@@ -507,7 +560,7 @@ while True:
             if debug:
                 log_cluster_data(section)
 
-            # Enable and disable pairs
+            # Enable and disable coins
             process_cluster_deals(section)
 
             # Update the bots in this cluster with the enabled/disabled pairs
@@ -518,12 +571,16 @@ while True:
                     action_id=str(bot),
                 )
                 if botdata:
-                    update_bot_pairs(section, botdata)
+                    update_bot_config(section, botdata)
                 else:
                     if boterror and "msg" in boterror:
                         logger.error("Error occurred updating bots: %s" % boterror["msg"])
                     else:
                         logger.error("Error occurred updating bots")
+
+            # Some coins could not be active in a bot, but we should inform other scripts about
+            # those excluded coins (prevent adding those coins)
+            write_cluster_exclude_files(section, botids)
 
             # Send notifications for the processed cluster, otherwise the message can
             # become too long resulting in a bad request

--- a/galaxyscore.py
+++ b/galaxyscore.py
@@ -216,7 +216,7 @@ def lunarcrush_pairs(cfg, thebot):
 
     # If sharedir is set, other scripts could provide a file with pairs to exclude
     if sharedir is not None:
-        remove_excluded_pairs(logger, sharedir, thebot["id"], newpairs)
+        remove_excluded_pairs(logger, sharedir, thebot['id'], marketcode, base, newpairs)
 
     if not newpairs:
         logger.info(
@@ -225,7 +225,8 @@ def lunarcrush_pairs(cfg, thebot):
         )
         return
 
-    # Lower the number of max deals if not enough new pairs and change allowed, change back to original if possible
+    # Lower the number of max deals if not enough new pairs and change allowed and
+    # change back to original if possible
     if allowmaxdealchange:
         if len(newpairs) < thebot["max_active_deals"]:
             newmaxdeals = len(newpairs)

--- a/helpers/misc.py
+++ b/helpers/misc.py
@@ -233,22 +233,25 @@ def get_botassist_data(logger, botassistlist, start_number, limit):
     return pairs
 
 
-def remove_excluded_pairs(logger, share_dir, bot_id, newpairs):
+def remove_excluded_pairs(logger, share_dir, bot_id, marketcode, base, newpairs):
     """Remove pairs which are excluded by other script(s)."""
 
-    excludedpairs = load_bot_excluded_pairs(logger, share_dir, bot_id, PAIREXCLUDE_EXT)
-    if excludedpairs:
+    excludedcoins = load_bot_excluded_coins(logger, share_dir, bot_id, PAIREXCLUDE_EXT)
+    if excludedcoins:
         logger.info(
-            f"Removing the following pair(s) for bot {bot_id}: {excludedpairs}"
+            f"Removing the following coin(s) for bot {bot_id}: {excludedcoins}"
         )
 
-        for pair in excludedpairs:
+        for coin in excludedcoins:
+            # Construct pair based on bot settings and marketcode
+            # (BTC stays BTC, but USDT can become BUSD)
+            pair = format_pair(logger, marketcode, base, coin)
             if newpairs.count(pair) > 0:
                 newpairs.remove(pair)
 
 
-def load_bot_excluded_pairs(logger, share_dir, bot_id, extension):
-    """Load excluded pairs from file, for the specified bot"""
+def load_bot_excluded_coins(logger, share_dir, bot_id, extension):
+    """Load excluded coins from file, for the specified bot"""
 
     excludedlist = []
     excludefilename = f"{share_dir}/{bot_id}.{extension}"
@@ -258,12 +261,12 @@ def load_bot_excluded_pairs(logger, share_dir, bot_id, extension):
             excludedlist = file.read().splitlines()
         if excludedlist:
             logger.info(
-                "Reading exclude file '%s' OK (%s pairs)"
+                "Reading exclude file '%s' OK (%s coins)"
                 % (excludefilename, len(excludedlist))
             )
     except FileNotFoundError:
         logger.info(
-            "Exclude file (%s) not found for bot '%s'; no pairs to exclude."
+            "Exclude file (%s) not found for bot '%s'; no coins to exclude."
             % (excludefilename, bot_id)
         )
 

--- a/helpers/misc.py
+++ b/helpers/misc.py
@@ -1,4 +1,5 @@
 """Cyberjunky's 3Commas bot helpers."""
+import datetime
 import time
 
 import requests
@@ -271,3 +272,9 @@ def load_bot_excluded_coins(logger, share_dir, bot_id, extension):
         )
 
     return excludedlist
+
+
+def unix_timestamp_to_string(timestamp, date_time_format):
+    """Convert the given timestamp to a readable date/time in the specified format"""
+
+    return datetime.datetime.fromtimestamp(timestamp).strftime(date_time_format)

--- a/trailingstoploss_tp.py
+++ b/trailingstoploss_tp.py
@@ -3,6 +3,7 @@
 import argparse
 import configparser
 import json
+from math import fabs
 import os
 import sqlite3
 import sys
@@ -10,14 +11,14 @@ import time
 from pathlib import Path
 
 from helpers.logging import Logger, NotificationHandler
-from helpers.misc import check_deal, wait_time_interval
+from helpers.misc import check_deal, unix_timestamp_to_string, wait_time_interval
 from helpers.threecommas import init_threecommas_api
 
 
 def load_config():
     """Create default or load existing config file."""
 
-    cfg = configparser.ConfigParser()
+    cfg = configparser.ConfigParser(strict=False)
     if cfg.read(f"{datadir}/{program}.ini"):
         return cfg
 
@@ -33,12 +34,23 @@ def load_config():
         "notify-urls": ["notify-url1"],
     }
 
+    cfgsectionconfig = list()
+    cfgsectionconfig.append({
+        "activation-percentage": "2.0",
+        "initial-stoploss-percentage": "0.5",
+        "sl-increment-factor": "0.0",
+        "tp-increment-factor": "0.0",
+    })
+    cfgsectionconfig.append({
+        "activation-percentage": "3.0",
+        "initial-stoploss-percentage": "2.0",
+        "sl-increment-factor": "0.4",
+        "tp-increment-factor": "0.4",
+    })
+
     cfg["tsl_tp_default"] = {
         "botids": [12345, 67890],
-        "activation-percentage": 3.0,
-        "initial-stoploss-percentage": 1.0,
-        "sl-increment-factor": 0.5,
-        "tp-increment-factor": 0.5,
+        "config": json.dumps(cfgsectionconfig)
     }
 
     with open(f"{datadir}/{program}.ini", "w") as cfgfile:
@@ -75,11 +87,33 @@ def upgrade_config(thelogger, cfg):
 
         thelogger.info("Upgraded the configuration file")
 
+    for cfgsection in cfg.sections():
+        if cfgsection.startswith("tsl_tp_") and not cfg.has_option(cfgsection, "config"):
+            cfgsectionconfig = list()
+            cfgsectionconfig.append({
+                "activation-percentage": cfg.get(cfgsection, "activation-percentage"),
+                "initial-stoploss-percentage": cfg.get(cfgsection, "initial-stoploss-percentage"),
+                "sl-increment-factor": cfg.get(cfgsection, "sl-increment-factor"),
+                "tp-increment-factor": cfg.get(cfgsection, "tp-increment-factor"),
+            })
+
+            cfg.set(cfgsection, "config", json.dumps(cfgsectionconfig))
+
+            cfg.remove_option(cfgsection, "activation-percentage")
+            cfg.remove_option(cfgsection, "initial-stoploss-percentage")
+            cfg.remove_option(cfgsection, "sl-increment-factor")
+            cfg.remove_option(cfgsection, "tp-increment-factor")
+
+            with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
+                cfg.write(cfgfile)
+
+            thelogger.info("Upgraded section %s to have config list" % cfgsection)
+
     return cfg
 
 
 def update_deal(thebot, deal, new_stoploss, new_take_profit):
-    """Update bot with new SL."""
+    """Update bot with new SL and TP."""
 
     bot_name = thebot["name"]
     deal_id = deal["id"]
@@ -98,7 +132,7 @@ def update_deal(thebot, deal, new_stoploss, new_take_profit):
         logger.info(
             f"Changing SL for deal {deal['pair']} ({deal_id}) on bot \"{bot_name}\"\n"
             f"Changed SL from {deal['stop_loss_percentage']}% to {new_stoploss}%. "
-            f"Changed TP from {deal['take_profit']}% to {new_take_profit}"
+            f"Changed TP from {deal['take_profit']}% to {new_take_profit}%"
         )
     else:
         if error and "msg" in error:
@@ -145,7 +179,26 @@ def calculate_average_price_sl_percentage_long(sl_price, average_price):
     )
 
 
-def process_deals(thebot):
+def get_config_for_profit(section_config, current_profit):
+    """Get the settings from the config corresponding to the current profit"""
+
+    profitconfig = {}
+
+    for entry in section_config:
+        if current_profit >= float(entry["activation-percentage"]):
+            profitconfig = entry
+        else:
+            break
+
+    logger.debug(
+        f"Profit config to use based on current profit {current_profit}% "
+        f"is {profitconfig}"
+    )
+
+    return profitconfig
+
+
+def process_deals(thebot, section_config):
     """Check deals from bot, compare against the database and handle them."""
 
     monitored_deals = 0
@@ -158,41 +211,45 @@ def process_deals(thebot):
 
         for deal in deals:
             deal_id = deal["id"]
-            deal_strategy = deal["strategy"]
 
-            if deal_strategy in ("short", "long"):
+            if deal["strategy"] in ("short", "long"):
                 current_deals.append(deal_id)
 
                 existing_deal = check_deal(cursor, deal_id)
+                actual_profit_config = get_config_for_profit(
+                        section_config, float(deal["actual_profit_percentage"])
+                    )
 
-                if not existing_deal and float(deal["actual_profit_percentage"]) >= activation_percentage:
+                if not existing_deal and actual_profit_config:
                     monitored_deals = +1
 
-                    handle_new_deal(thebot, deal, deal_strategy)
+                    handle_new_deal(thebot, deal, actual_profit_config)
                 elif existing_deal:
                     deal_sl = deal["stop_loss_percentage"]
                     current_stoploss_percentage = 0.0 if deal_sl is None else float(deal_sl)
                     if current_stoploss_percentage != 0.0:
                         monitored_deals = +1
 
-                        handle_update_deal(thebot, deal, existing_deal, deal_strategy)
+                        handle_update_deal(
+                                thebot, deal, existing_deal, actual_profit_config
+                            )
                     else:
                         # Existing deal, but stoploss is 0.0 which means it has been reset
                         remove_active_deal(deal_id)
             else:
                 logger.warning(
-                    f"Unknown strategy {deal_strategy} for deal {deal_id}"
+                    f"Unknown strategy {deal['strategy']} for deal {deal_id}"
                 )
 
         # Housekeeping, clean things up and prevent endless growing database
         remove_closed_deals(botid, current_deals)
 
-        logger.info(
+        logger.debug(
             f"Bot \"{thebot['name']}\" ({botid}) has {len(deals)} deal(s) "
             f"of which {monitored_deals} require monitoring."
         )
     else:
-        logger.info(
+        logger.debug(
             f"Bot \"{thebot['name']}\" ({botid}) has no active deals."
         )
         remove_all_deals(botid)
@@ -200,24 +257,19 @@ def process_deals(thebot):
     return monitored_deals
 
 
-def handle_new_deal(thebot, deal, strategy):
-    """New deal (short or long) to activate SL on"""
+def calculate_sl_percentage(deal_data, profit_config, activation_diff):
+    """Calculate the SL percentage in 3C range"""
 
-    botid = thebot["id"]
-    deal_id = deal["id"]
-    pair = deal['pair']
-    actual_profit_percentage = float(deal["actual_profit_percentage"])
-
-    # Take space between trigger and actual profit into account
-    activation_diff = actual_profit_percentage - activation_percentage
+    initial_stoploss_percentage = float(profit_config.get("initial-stoploss-percentage"))
+    sl_increment_factor = float(profit_config.get("sl-increment-factor"))
 
     # SL is calculated by 3C on base order price. Because of filled SO's,
     # we must first calculate the SL price based on the average price
     average_price = 0.0
-    if strategy == "short":
-        average_price = float(deal["sold_average_price"])
+    if deal_data["strategy"] == "short":
+        average_price = float(deal_data["sold_average_price"])
     else:
-        average_price = float(deal["bought_average_price"])
+        average_price = float(deal_data["bought_average_price"])
 
     # Calculate the amount we need to substract or add to the average price based
     # on the configured increments and activation
@@ -225,23 +277,23 @@ def handle_new_deal(thebot, deal, strategy):
                                         + ((activation_diff / 100.0) * sl_increment_factor))
 
     sl_price = average_price
-    if strategy == "short":
+    if deal_data["strategy"] == "short":
         sl_price -= percentage_price
     else:
         sl_price += percentage_price
 
     logger.debug(
-        f"{pair}/{deal_id}: SL price {sl_price} calculated based on average "
+        f"{deal_data['pair']}/{deal_data['id']}: SL price {sl_price} calculated based on average "
         f"price {average_price}, initial SL of {initial_stoploss_percentage}, "
         f"activation diff of {activation_diff} and sl factor {sl_increment_factor}"
     )
 
     # Now we know the SL price, let's calculate the percentage from
     # the base order price so we have the desired SL for 3C
-    base_price = float(deal["base_order_average_price"])
+    base_price = float(deal_data["base_order_average_price"])
     base_price_sl_percentage = 0.0
 
-    if strategy == "short":
+    if deal_data["strategy"] == "short":
         base_price_sl_percentage = calculate_slpercentage_base_price_short(
                 sl_price, base_price
             )
@@ -251,41 +303,61 @@ def handle_new_deal(thebot, deal, strategy):
             )
 
     logger.debug(
-        f"{pair}/{deal_id}: base SL of {base_price_sl_percentage}% calculated "
+        f"{deal_data['pair']}/{deal_data['id']}: base SL of {base_price_sl_percentage}% calculated "
         f"based on base price {base_price} and SL price {sl_price}."
     )
 
-    if base_price_sl_percentage != 0.00:
-        # Calculate understandable SL percentage based on average price
+    return average_price, sl_price, base_price_sl_percentage
+
+
+def handle_new_deal(thebot, deal, profit_config):
+    """New deal (short or long) to activate SL on"""
+
+    botid = thebot["id"]
+    actual_profit_percentage = float(deal["actual_profit_percentage"])
+
+    activation_percentage = float(profit_config.get("activation-percentage"))
+
+    # Take space between trigger and actual profit into account
+    activation_diff = actual_profit_percentage - activation_percentage
+
+    # SL data contains three values:
+    # 0. The sold or bought average price
+    # 1. The calculated SL price
+    # 2. The SL percentage on 3C axis (inverted range compared to TP axis)
+    sl_data = calculate_sl_percentage(deal, profit_config, activation_diff)
+
+    if sl_data[2] != 0.00:
+        # Calculate understandable SL percentage (TP axis range) based on average price
         average_price_sl_percentage = 0.0
 
-        if strategy == "short":
+        if deal["strategy"] == "short":
             average_price_sl_percentage = calculate_average_price_sl_percentage_short(
-                    sl_price, average_price
+                    sl_data[1], sl_data[0]
                 )
         else:
             average_price_sl_percentage = calculate_average_price_sl_percentage_long(
-                    sl_price, average_price
+                    sl_data[1], sl_data[0]
                 )
 
         logger.debug(
-            f"{pair}/{deal_id}: average SL of {average_price_sl_percentage}% "
-            f"calculated based on average price {average_price} and "
-            f"SL price {sl_price}."
+            f"{deal['pair']}/{deal['id']}: average SL of {average_price_sl_percentage}% "
+            f"calculated based on average price {sl_data[0]} and "
+            f"SL price {sl_data[1]}."
         )
 
         # Calculate new TP percentage
         current_tp_percentage = float(deal["take_profit"])
         new_tp_percentage = round(
             current_tp_percentage
-            + (activation_diff * tp_increment_factor),
+            + (activation_diff * float(profit_config.get("tp-increment-factor"))),
             2
         )
 
         logger.info(
-            f"\"{thebot['name']}\": {pair}/{deal_id} profit ({actual_profit_percentage}%) above "
-            f"activation ({activation_percentage}%). StopLoss activated "
-            f"on {average_price_sl_percentage}%.",
+            f"\"{thebot['name']}\": {deal['pair']}/{deal['id']} "
+            f"profit ({actual_profit_percentage}%) above activation ({activation_percentage}%). "
+            f"StopLoss activated on {average_price_sl_percentage}%.",
             True
         )
 
@@ -296,140 +368,107 @@ def handle_new_deal(thebot, deal, strategy):
                 True
             )
 
-        update_deal(thebot, deal, base_price_sl_percentage, new_tp_percentage)
+        # Update deal in 3C
+        update_deal(thebot, deal, sl_data[2], new_tp_percentage)
 
-        db.execute(
-            f"INSERT INTO deals (dealid, botid, last_profit_percentage, last_stop_loss_percentage) "
-            f"VALUES ({deal_id}, {botid}, {actual_profit_percentage}, {base_price_sl_percentage})"
+        # Add deal to our database
+        add_deal_in_db(
+            deal["id"], botid, actual_profit_percentage, average_price_sl_percentage, new_tp_percentage
         )
-
-        db.commit()
     else:
-        logger.info(
-            f"{pair}/{deal_id}: calculated SL of {base_price_sl_percentage} which "
+        logger.debug(
+            f"{deal['pair']}/{deal['id']}: calculated SL of {sl_data[2]} which "
             f"will cause 3C not to activate SL. No action taken!"
         )
 
 
-def handle_update_deal(thebot, deal, existing_deal, strategy):
+def handle_update_deal(thebot, deal, existing_deal, profit_config):
     """Update deal (short or long) and increase SL (Trailing SL) when profit has increased."""
 
-    deal_id = deal["id"]
-    pair = deal['pair']
     actual_profit_percentage = float(deal["actual_profit_percentage"])
     last_profit_percentage = float(existing_deal["last_profit_percentage"])
 
     if actual_profit_percentage > last_profit_percentage:
-        # Existing deal with TSL and profit increased, so move TSL
-        # Because initial SL was calculated correctly, we only have
-        # to adjust with the profit change
-        current_sl_percentage = float(deal["stop_loss_percentage"])
-        current_tp_percentage = float(deal["take_profit"])
-        profit_diff = actual_profit_percentage - last_profit_percentage
+        sl_increment_factor = float(profit_config.get("sl-increment-factor"))
+        tp_increment_factor = float(profit_config.get("tp-increment-factor"))
 
-        new_base_price_sl_percentage = round(
-            current_sl_percentage - (profit_diff * sl_increment_factor), 2
-        )
+        if sl_increment_factor > 0.0 or tp_increment_factor > 0.0:
+            activation_diff = actual_profit_percentage - float(profit_config.get("activation-percentage"))
 
-        logger.debug(
-            f"{pair}/{deal_id}: new base SL of {new_base_price_sl_percentage}% "
-            f"calculated based on current SL {current_sl_percentage}%, "
-            f"profit diff {profit_diff} and increment {sl_increment_factor}."
-        )
+            # SL data contains three values:
+            # 0. The sold or bought average price
+            # 1. The calculated SL price
+            # 2. The SL percentage on 3C axis (inverted range compared to TP axis)
+            sl_data = calculate_sl_percentage(deal, profit_config, activation_diff)
 
-        if new_base_price_sl_percentage != 0.00:
-            new_tp_percentage = round(
-                current_tp_percentage + (profit_diff * tp_increment_factor), 2
-            )
+            current_sl_percentage = float(deal["stop_loss_percentage"])
+            if fabs(sl_data[2]) > 0.0 and sl_data[2] != current_sl_percentage:
+                # Calculate understandable SL percentage (TP axis range) based on average price
+                new_average_price_sl_percentage = 0.0
 
-            # Calculate understandable SL percentage based on bought average price
-            # First calculate the base prices for current and new SL %
-            base_price = float(deal["base_order_average_price"])
+                if deal["strategy"] == "short":
+                    new_average_price_sl_percentage = calculate_average_price_sl_percentage_short(
+                            sl_data[1], sl_data[0]
+                        )
+                else:
+                    new_average_price_sl_percentage = calculate_average_price_sl_percentage_long(
+                            sl_data[1], sl_data[0]
+                        )
 
-            percentage_current_price = ((base_price / 100.0) * current_sl_percentage)
-            percentage_new_price = ((base_price / 100.0) * new_base_price_sl_percentage)
+                logger.debug(
+                    f"{deal['pair']}/{deal['id']}: new average SL "
+                    f"of {new_average_price_sl_percentage}% calculated "
+                    f"based on average price {sl_data[0]} and "
+                    f"SL price {sl_data[1]}."
+                )
 
-            current_base_sl_price = base_price
-            new_base_sl_price = base_price
-
-            if strategy == "short":
-                current_base_sl_price += percentage_current_price
-                new_base_sl_price += percentage_new_price
-            else:
-                current_base_sl_price -= percentage_current_price
-                new_base_sl_price -= percentage_new_price
-
-            logger.debug(
-                f"{pair}/{deal_id}: current SL price of {current_base_sl_price} "
-                f"on base price {base_price} and {current_sl_percentage}%. New "
-                f"SL price {new_base_sl_price} on base price {base_price} "
-                f"and {new_base_price_sl_percentage}%."
-            )
-
-            # Then calculate the SL % based on the average price, same axis as TP %
-            average_price = 0.0
-            current_average_price_sl_percentage = 0.0
-            new_average_price_sl_percentage = 0.0
-
-            if strategy == "short":
-                average_price = float(deal["sold_average_price"])
-
-                current_average_price_sl_percentage = calculate_average_price_sl_percentage_short(
-                        current_base_sl_price, average_price
-                    )
-                new_average_price_sl_percentage = calculate_average_price_sl_percentage_short(
-                        new_base_sl_price, average_price
-                    )
-            else:
-                average_price = float(deal["bought_average_price"])
-
-                current_average_price_sl_percentage = calculate_average_price_sl_percentage_long(
-                        current_base_sl_price, average_price
-                    )
-                new_average_price_sl_percentage = calculate_average_price_sl_percentage_long(
-                        new_base_sl_price, average_price
-                    )
-
-            logger.debug(
-                f"{pair}/{deal_id}: average SL {current_average_price_sl_percentage}% "
-                f"based on base sl price {current_base_sl_price} and average price "
-                f"{average_price}. New average SL {new_average_price_sl_percentage}% "
-                f"based on new base sl price {new_base_sl_price} and average price "
-                f"{average_price}."
-            )
-
-            logger.info(
-                f"\"{thebot['name']}\": {pair}/{deal_id} profit increased "
-                f"from {last_profit_percentage}% to {actual_profit_percentage}%. "
-                f"StopLoss increased from {current_average_price_sl_percentage}% to "
-                f"{new_average_price_sl_percentage}%. ",
-                True
-            )
-
-            if new_tp_percentage > current_tp_percentage:
                 logger.info(
-                    f"TakeProfit increased from {current_tp_percentage}% "
-                    f"to {new_tp_percentage}%",
+                    f"\"{thebot['name']}\": {deal['pair']}/{deal['id']} profit increased "
+                    f"from {last_profit_percentage}% to {actual_profit_percentage}%. "
+                    f"StopLoss increased from {existing_deal['last_readable_sl_percentage']}% to "
+                    f"{new_average_price_sl_percentage}%. ",
                     True
                 )
 
-            update_deal(thebot, deal, new_base_price_sl_percentage, new_tp_percentage)
+                # Calculate new TP percentage based on the increased profit and increment factor
+                current_tp_percentage = float(deal["take_profit"])
+                new_tp_percentage = round(
+                    current_tp_percentage + (
+                            (actual_profit_percentage - last_profit_percentage)
+                            * tp_increment_factor
+                        ), 2
+                )
 
-            db.execute(
-                f"UPDATE deals SET last_profit_percentage = {actual_profit_percentage}, "
-                f"last_stop_loss_percentage = {new_base_price_sl_percentage} "
-                f"WHERE dealid = {deal_id}"
-            )
+                if new_tp_percentage > current_tp_percentage:
+                    logger.info(
+                        f"TakeProfit increased from {current_tp_percentage}% "
+                        f"to {new_tp_percentage}%",
+                        True
+                    )
 
-            db.commit()
+                # Update deal in 3C
+                update_deal(thebot, deal, sl_data[2], new_tp_percentage)
+
+                # Update deal in our database
+                update_deal_in_db(
+                    deal['id'], actual_profit_percentage, new_average_price_sl_percentage, new_tp_percentage
+                )
+            else:
+                logger.debug(
+                    f"{deal['pair']}/{deal['id']}: calculated SL of {sl_data[2]}% which "
+                    f"is equal to current SL {current_sl_percentage}% or "
+                    f"is 0.0 which causes 3C to deactive SL; no change made!"
+                )
         else:
-            logger.info(
-                f"{pair}/{deal_id}: calculated SL of 0.0 which will cause 3C "
-                f"to deactive SL; no update this round!"
+            logger.debug(
+                f"{deal['pair']}/{deal['id']}: profit increased from {last_profit_percentage}% "
+                f"to {actual_profit_percentage}%, but increment factors are 0.0 so "
+                f"no change required for this deal."
             )
     else:
-        logger.info(
-            f"{pair}/{deal_id}: no profit increase (current: {actual_profit_percentage}%, "
+        logger.debug(
+            f"{deal['pair']}/{deal['id']}: no profit increase "
+            f"(current: {actual_profit_percentage}%, "
             f"previous: {last_profit_percentage}%). Keep on monitoring."
         )
 
@@ -456,7 +495,7 @@ def remove_closed_deals(bot_id, current_deals):
         # Remove start and end square bracket so we can properly use it
         current_deals_str = str(current_deals)[1:-1]
 
-        logger.info(f"Deleting old deals from bot {bot_id} except {current_deals_str}")
+        logger.debug(f"Deleting old deals from bot {bot_id} except {current_deals_str}")
         db.execute(
             f"DELETE FROM deals WHERE botid = {bot_id} AND dealid NOT IN ({current_deals_str})"
         )
@@ -467,7 +506,7 @@ def remove_closed_deals(bot_id, current_deals):
 def remove_all_deals(bot_id):
     """Remove all stored deals for the specified bot."""
 
-    logger.info(
+    logger.debug(
         f"Removing all stored deals for bot {bot_id}."
     )
 
@@ -478,7 +517,72 @@ def remove_all_deals(bot_id):
     db.commit()
 
 
-def init_tsl_db():
+def get_bot_next_process_time(bot_id):
+    """Get the next processing time for the specified bot."""
+
+    dbrow = cursor.execute(
+            f"SELECT next_processing_timestamp FROM bots WHERE botid = {bot_id}"
+        ).fetchone()
+
+    nexttime = int(time.time())
+    if dbrow is not None:
+        nexttime = dbrow["next_processing_timestamp"]
+    else:
+        # Record missing, create one
+        set_bot_next_process_time(bot_id, nexttime)
+
+    return nexttime
+
+
+def set_bot_next_process_time(bot_id, new_time):
+    """Set the next processing time for the specified bot."""
+
+    logger.debug(
+        f"Next processing for bot {bot_id} not before "
+        f"{unix_timestamp_to_string(new_time, '%Y-%m-%d %H:%M:%S')}."
+    )
+
+    db.execute(
+        f"REPLACE INTO bots (botid, next_processing_timestamp) "
+        f"VALUES ({bot_id}, {new_time})"
+    )
+
+    db.commit()
+
+
+def add_deal_in_db(deal_id, bot_id, tp_percentage, readable_sl_percentage, readable_tp_percentage):
+    """Add deal (short or long) to database."""
+
+    db.execute(
+        f"INSERT INTO deals ("
+        f"dealid, "
+        f"botid, "
+        f"last_profit_percentage, "
+        f"last_readable_sl_percentage, "
+        f"last_readable_tp_percentage) "
+        f"VALUES ("
+        f"{deal_id}, {bot_id}, {tp_percentage}, {readable_sl_percentage}, {readable_tp_percentage}"
+        f")"
+    )
+
+    db.commit()
+
+
+def update_deal_in_db(deal_id, tp_percentage, readable_sl_percentage, readable_tp_percentage):
+    """Update deal (short or long) in database."""
+
+    db.execute(
+        f"UPDATE deals SET "
+        f"last_profit_percentage = {tp_percentage}, "
+        f"last_readable_sl_percentage = {readable_sl_percentage}, "
+        f"last_readable_tp_percentage = {readable_tp_percentage} "
+        f"WHERE dealid = {deal_id}"
+    )
+
+    db.commit()
+
+
+def open_tsl_db():
     """Create or open database to store bot and deals data."""
 
     try:
@@ -496,16 +600,48 @@ def init_tsl_db():
         logger.info(f"Database '{datadir}/{dbname}' created successfully")
 
         dbcursor.execute(
-            "CREATE TABLE deals ("
+            "CREATE TABLE IF NOT EXISTS deals ("
             "dealid INT Primary Key, "
             "botid INT, "
             "last_profit_percentage FLOAT, "
-            "last_stop_loss_percentage FLOAT"
+            "last_readable_sl_percentage FLOAT, "
+            "last_readable_tp_percentage FLOAT "
             ")"
         )
+
+        dbcursor.execute(
+            "CREATE TABLE IF NOT EXISTS bots ("
+            "botid INT Primary Key, "
+            "next_processing_timestamp INT"
+            ")"
+        )
+
         logger.info("Database tables created successfully")
 
     return dbconnection
+
+
+def upgrade_trailingstoploss_tp_db():
+    """Upgrade database if needed."""
+    try:
+        try:
+            # DROP column supported from sqlite 3.35.0 (2021.03.12)
+            cursor.execute("ALTER TABLE deals DROP COLUMN last_stop_loss_percentage")
+        except sqlite3.OperationalError:
+            logger.debug("Older SQLite version; not used column not removed")
+
+        cursor.execute("ALTER TABLE deals ADD COLUMN last_readable_sl_percentage FLOAT")
+        cursor.execute("ALTER TABLE deals ADD COLUMN last_readable_tp_percentage FLOAT")
+
+        cursor.execute(
+            "CREATE TABLE IF NOT EXISTS bots ("
+            "botid INT Primary Key, "
+            "next_processing_timestamp INT"
+            ")"
+        )
+        logger.info("Database schema upgraded")
+    except sqlite3.OperationalError:
+        logger.debug("Database schema is up-to-date")
 
 
 # Start application
@@ -564,8 +700,11 @@ else:
 api = init_threecommas_api(config)
 
 # Initialize or open the database
-db = init_tsl_db()
+db = open_tsl_db()
 cursor = db.cursor()
+
+# Upgrade the database if needed
+upgrade_trailingstoploss_tp_db()
 
 # TrailingStopLoss and TakeProfit %
 while True:
@@ -580,38 +719,56 @@ while True:
     # Used to determine the correct interval
     deals_to_monitor = 0
 
+    # Current time to determine which bots to process
+    starttime = int(time.time())
+
     for section in config.sections():
         if section.startswith("tsl_tp_"):
             # Bot configuration for section
             botids = json.loads(config.get(section, "botids"))
 
-            activation_percentage = float(
-                json.loads(config.get(section, "activation-percentage"))
-            )
-            initial_stoploss_percentage = float(
-                json.loads(config.get(section, "initial-stoploss-percentage"))
-            )
-            sl_increment_factor = float(
-                json.loads(config.get(section, "sl-increment-factor"))
-            )
-            tp_increment_factor = float(
-                json.loads(config.get(section, "tp-increment-factor"))
-            )
+            # Get and check the config for this section
+            sectionconfig = json.loads(config.get(section, "config"))
+            if len(sectionconfig) == 0:
+                logger.warning(
+                    f"Section {section} has an empty \'config\'. Skipping this section!"
+                )
+                continue
 
             # Walk through all bots configured
             for bot in botids:
-                boterror, botdata = api.request(
-                    entity="bots",
-                    action="show",
-                    action_id=str(bot),
-                )
-                if botdata:
-                    deals_to_monitor += process_deals(botdata)
-                else:
-                    if boterror and "msg" in boterror:
-                        logger.error("Error occurred updating bots: %s" % boterror["msg"])
+                nextprocesstime = get_bot_next_process_time(bot)
+
+                # Only process the bot if it's time for the next interval, or
+                # time exceeds the check interval (clock has changed somehow)
+                if starttime >= nextprocesstime or (
+                        abs(nextprocesstime - starttime) > check_interval
+                ):
+                    boterror, botdata = api.request(
+                        entity="bots",
+                        action="show",
+                        action_id=str(bot),
+                    )
+                    if botdata:
+                        bot_deals_to_monitor = process_deals(botdata, sectionconfig)
+
+                        # Determine new time to process this bot, based on the monitored deals
+                        newtime = starttime + (
+                                check_interval if bot_deals_to_monitor == 0 else monitor_interval
+                            )
+                        set_bot_next_process_time(bot, newtime)
+
+                        deals_to_monitor += bot_deals_to_monitor
                     else:
-                        logger.error("Error occurred updating bots")
+                        if boterror and "msg" in boterror:
+                            logger.error("Error occurred updating bots: %s" % boterror["msg"])
+                        else:
+                            logger.error("Error occurred updating bots")
+                else:
+                    logger.debug(
+                        f"Bot {bot} will be processed after "
+                        f"{unix_timestamp_to_string(nextprocesstime, '%Y-%m-%d %H:%M:%S')}."
+                    )
 
     timeint = check_interval if deals_to_monitor == 0 else monitor_interval
     if not wait_time_interval(logger, notification, timeint, False):

--- a/volatility.py
+++ b/volatility.py
@@ -157,7 +157,7 @@ def lunarcrush_pairs(thebot):
 
     # If sharedir is set, other scripts could provide a file with pairs to exclude
     if sharedir is not None:
-        remove_excluded_pairs(logger, sharedir, thebot['id'], newpairs)
+        remove_excluded_pairs(logger, sharedir, thebot['id'], marketcode, base, newpairs)
 
     if not newpairs:
         logger.info(


### PR DESCRIPTION
Two changes combined; 
- advanced trailingstoploss_tp allowing multiple configurations to be used and more specific control over the SL changes.
- dealcluster works now based on the coin (quote) instead of the complete pair, allowing the base (BTC, BUSD, ed) to be mixed inside one cluster.