### PR TITLE
Fixes script crash for abandoned pairs on exchange

### DIFF
--- a/trailingstoploss_tp.py
+++ b/trailingstoploss_tp.py
@@ -566,7 +566,7 @@ def add_deal_in_db(deal_id, bot_id, tp_percentage, readable_sl_percentage, reada
     """Add deal (short or long) to database."""
 
     db.execute(
-        f"INSERT INTO deals ("
+        f"INSERT or REPLACE INTO deals ("
         f"dealid, "
         f"botid, "
         f"last_profit_percentage, "

--- a/trailingstoploss_tp.py
+++ b/trailingstoploss_tp.py
@@ -178,6 +178,12 @@ def calculate_average_price_sl_percentage_long(sl_price, average_price):
         2
     )
 
+def check_float(potential_float):
+    try:
+        float(potential_float)
+        return True
+    except ValueError:
+        return False
 
 def get_config_for_profit(section_config, current_profit):
     """Get the settings from the config corresponding to the current profit"""
@@ -216,9 +222,15 @@ def process_deals(thebot, section_config):
                 current_deals.append(deal_id)
 
                 existing_deal = check_deal(cursor, deal_id)
-                actual_profit_config = get_config_for_profit(
+                # Prevent crash when in some cases exchange is dropping pairs while deal was not closed by 3commas
+                if check_float(deal["actual_profit_percentage"]):
+                    actual_profit_config = get_config_for_profit(
                         section_config, float(deal["actual_profit_percentage"])
-                    )
+                        )
+                else:
+                    logger.info("Dealid " + str(deal_id) + " with pair " + str(deal["pair"]) 
+                    + " not existent on exchange anymore. Please cancel deal manually on 3Commas")
+                    actual_profit_config = {}
 
                 if not existing_deal and actual_profit_config:
                     monitored_deals = +1

--- a/trailingstoploss_tp.py
+++ b/trailingstoploss_tp.py
@@ -14,21 +14,6 @@ from helpers.logging import Logger, NotificationHandler
 from helpers.misc import check_deal, unix_timestamp_to_string, wait_time_interval
 from helpers.threecommas import init_threecommas_api
 
-import portalocker
-# Check for single instance run
-fh = 0
-def run_once():
-    global fh
-    fh = open(os.path.realpath(__file__), "r")
-    try:
-        portalocker.lock(fh, portalocker.LOCK_EX | portalocker.LOCK_NB)
-    except:
-        sys.exit(
-            "Only one instance running allowed!"
-        )
-
-run_once()
-
 def load_config():
     """Create default or load existing config file."""
 


### PR DESCRIPTION
When checking for deals, which were not closed by 3commas but by the exchange (removal of trading pair), the returned deal["actual_profit_percentage"] is empty and cannot be converted to float. This causes to exit the script with an error. 