### PR TITLE
Update for 3C API with self-signed key

### DIFF
--- a/allpairs.py
+++ b/allpairs.py
@@ -33,6 +33,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
+        "3c-apiselfsigned": "Your own generated API key, or empty",
         "notifications": False,
         "notify-urls": ["notify-url1"],
         "botids": [12345, 67890],
@@ -42,6 +43,20 @@ def load_config():
         cfg.write(cfgfile)
 
     return None
+
+
+def upgrade_config(cfg):
+    """Upgrade config file if needed."""
+
+    if not cfg.has_option("settings", "3c-apiselfsigned"):
+        cfg.set("settings", "3c-apiselfsigned", "")
+
+        with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
+            cfg.write(cfgfile)
+
+        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+
+    return cfg
 
 
 def all_pairs(thebot):
@@ -155,6 +170,9 @@ else:
         config.getboolean("settings", "debug"),
         config.getboolean("settings", "notifications"),
     )
+
+    # Upgrade config file if needed
+    config = upgrade_config(config)
 
     logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 

--- a/altrank.py
+++ b/altrank.py
@@ -44,6 +44,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
+        "3c-apiselfsigned": "Your own generated API key, or empty",
         "lc-apikey": "Your LunarCrush API Key",
         "lc-fetchlimit": 150,
         "notifications": False,
@@ -65,7 +66,7 @@ def load_config():
     return None
 
 
-def upgrade_config(thelogger, theapi, cfg):
+def upgrade_config(cfg):
     """Upgrade config file if needed."""
 
     try:
@@ -74,47 +75,6 @@ def upgrade_config(thelogger, theapi, cfg):
         logger.error(f"Upgrading config file '{datadir}/{program}.ini'")
         cfg.set("settings", "lc-fetchlimit", "150")
 
-    if cfg.has_option("settings", "botids"):
-        thebotids = json.loads(cfg.get("settings", "botids"))
-
-        default_numberofpairs = int(config.get("settings", "numberofpairs"))
-        default_maxaltrankscore = int(
-            config.get("settings", "maxaltrankscore", fallback=1500)
-        )
-
-        # Walk through all bots configured
-        for thebot in thebotids:
-            if not cfg.has_section(f"bot_{thebot}"):
-
-                error, data = theapi.request(
-                    entity="bots",
-                    action="show",
-                    action_id=str(thebot),
-                )
-                if data:
-                    # Add new config section
-                    cfg[f"bot_{thebot}"] = {
-                        "maxaltrankscore": default_maxaltrankscore,
-                        "numberofpairs": default_numberofpairs,
-                        "originalmaxdeals": int(data["max_active_deals"]),
-                        "allowmaxdealchange": False,
-                        "comment": data["name"].replace('%','%%'),
-                    }
-                else:
-                    if error and "msg" in error:
-                        logger.error(
-                            "Error occurred upgrading config: %s" % error["msg"]
-                        )
-                    else:
-                        logger.error("Error occurred upgrading config")
-
-        cfg.remove_option("settings", "botids")
-
-        with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
-            cfg.write(cfgfile)
-
-        thelogger.info("Upgraded the configuration file (create sections)")
-
     for cfgsection in cfg.sections():
         if cfgsection.startswith("bot_") and not cfg.has_option(cfgsection, "allowbotstopstart"):
             cfg.set(cfgsection, "allowbotstopstart", "False")
@@ -122,7 +82,15 @@ def upgrade_config(thelogger, theapi, cfg):
             with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
                 cfg.write(cfgfile)
 
-            thelogger.info("Upgraded the configuration file (bot stop-start)")
+            logger.info("Upgraded the configuration file (bot stop-start)")
+
+    if not cfg.has_option("settings", "3c-apiselfsigned"):
+        cfg.set("settings", "3c-apiselfsigned", "")
+
+        with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
+            cfg.write(cfgfile)
+
+        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
 
     return cfg
 
@@ -334,11 +302,13 @@ else:
         config.getboolean("settings", "notifications"),
     )
 
+    # Upgrade config file if needed
+    config = upgrade_config(config)
+
+    logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
+
 # Initialize 3Commas API
 api = init_threecommas_api(config)
-
-# Upgrade config file if needed
-config = upgrade_config(logger, api, config)
 
 logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 

--- a/balancereport.py
+++ b/balancereport.py
@@ -44,6 +44,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
+        "3c-apiselfsigned": "Your own generated API key, or empty",
         "notifications": False,
         "notify-urls": ["notify-url1"],
         "conditional-botids": [],
@@ -65,6 +66,14 @@ def upgrade_config(cfg):
             cfg.write(cfgfile)
 
         logger.info("Upgraded section settings to have conditional-botids")
+
+    if not cfg.has_option("settings", "3c-apiselfsigned"):
+        cfg.set("settings", "3c-apiselfsigned", "")
+
+        with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
+            cfg.write(cfgfile)
+
+        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
 
     return cfg
 

--- a/botupdater.py
+++ b/botupdater.py
@@ -44,6 +44,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
+        "3c-apiselfsigned": "Your own generated API key, or empty",
         "notifications": False,
         "notify-urls": ["notify-url1"],
     }
@@ -142,6 +143,14 @@ def upgrade_config(cfg):
                 cfg.write(cfgfile)
 
             logger.info("Upgraded section %s to have notify option" % cfgsection)
+
+    if not cfg.has_option("settings", "3c-apiselfsigned"):
+        cfg.set("settings", "3c-apiselfsigned", "")
+
+        with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
+            cfg.write(cfgfile)
+
+        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
 
     return cfg
 

--- a/coinmarketcap.py
+++ b/coinmarketcap.py
@@ -46,6 +46,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
+        "3c-apiselfsigned": "Your own generated API key, or empty",
         "cmc-apikey": "Your CoinMarketCap API Key",
         "notifications": False,
         "notify-urls": ["notify-url1"],
@@ -67,7 +68,7 @@ def load_config():
     return None
 
 
-def upgrade_config(thelogger, cfg):
+def upgrade_config(cfg):
     """Upgrade config file if needed."""
 
     if cfg.has_option("settings", "numberofpairs"):
@@ -81,7 +82,7 @@ def upgrade_config(thelogger, cfg):
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        thelogger.info("Upgraded the configuration file")
+        logger.info("Upgraded the configuration file")
 
     if len(cfg.sections()) == 1:
         # Old configuration containing only one section (settings)
@@ -105,7 +106,7 @@ def upgrade_config(thelogger, cfg):
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        thelogger.info("Upgraded the configuration file")
+        logger.info("Upgraded the configuration file")
 
     for cfgsection in cfg.sections():
         if cfgsection.startswith("cmc_"):
@@ -119,9 +120,17 @@ def upgrade_config(thelogger, cfg):
                 with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
                     cfg.write(cfgfile)
 
-                thelogger.info(
+                logger.info(
                     "Upgraded the configuration file (max-percent-change)"
                 )
+
+    if not cfg.has_option("settings", "3c-apiselfsigned"):
+        cfg.set("settings", "3c-apiselfsigned", "")
+
+        with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
+            cfg.write(cfgfile)
+
+        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
 
     return cfg
 
@@ -357,7 +366,7 @@ else:
     )
 
     # Upgrade config file if needed
-    config = upgrade_config(logger, config)
+    config = upgrade_config(config)
 
     logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 

--- a/compound.py
+++ b/compound.py
@@ -39,6 +39,7 @@ def load_config():
         "default-profittocompound": 1.0,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
+        "3c-apiselfsigned": "Your own generated API key, or empty",
         "notifications": False,
         "notify-urls": ["notify-url1", "notify-url2"],
     }
@@ -56,7 +57,7 @@ def load_config():
     return None
 
 
-def upgrade_config(thelogger, theapi, cfg):
+def upgrade_config(theapi, cfg):
     """Upgrade config file if needed."""
 
     if cfg.has_option("settings", "profittocompound"):
@@ -70,7 +71,7 @@ def upgrade_config(thelogger, theapi, cfg):
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        thelogger.info("Upgraded the configuration file (default-profittocompound)")
+        logger.info("Upgraded the configuration file (default-profittocompound)")
 
     if cfg.has_option("settings", "botids"):
         thebotids = json.loads(cfg.get("settings", "botids"))
@@ -109,7 +110,15 @@ def upgrade_config(thelogger, theapi, cfg):
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        thelogger.info("Upgraded the configuration file (create sections)")
+        logger.info("Upgraded the configuration file (create sections)")
+
+    if not cfg.has_option("settings", "3c-apiselfsigned"):
+        cfg.set("settings", "3c-apiselfsigned", "")
+
+        with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
+            cfg.write(cfgfile)
+
+        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
 
     return cfg
 
@@ -868,7 +877,7 @@ else:
 api = init_threecommas_api(config)
 
 # Upgrade config file if needed
-config = upgrade_config(logger, api, config)
+config = upgrade_config(api, config)
 
 logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 

--- a/dealcluster.py
+++ b/dealcluster.py
@@ -42,6 +42,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
+        "3c-apiselfsigned": "Your own generated API key, or empty",
         "notifications": False,
         "notify-urls": ["notify-url1"],
     }
@@ -57,10 +58,16 @@ def load_config():
     return None
 
 
-def upgrade_config(thelogger, cfg):
+def upgrade_config(cfg):
     """Upgrade config file if needed."""
 
-    thelogger.info("Config does not require any upgrade at this moment")
+    if not cfg.has_option("settings", "3c-apiselfsigned"):
+        cfg.set("settings", "3c-apiselfsigned", "")
+
+        with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
+            cfg.write(cfgfile)
+
+        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
 
     return cfg
 
@@ -520,7 +527,7 @@ else:
     )
 
     # Upgrade config file if needed
-    config = upgrade_config(logger, config)
+    config = upgrade_config(config)
 
     logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 

--- a/gridbot.py
+++ b/gridbot.py
@@ -31,6 +31,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
+        "3c-apiselfsigned": "Your own generated API key, or empty",
         "notifications": False,
         "notify-urls": ["notify-url1", "notify-url2"],
     }
@@ -49,6 +50,20 @@ def load_config():
         cfg.write(cfgfile)
 
     return None
+
+
+def upgrade_config(cfg):
+    """Upgrade config file if needed."""
+
+    if not cfg.has_option("settings", "3c-apiselfsigned"):
+        cfg.set("settings", "3c-apiselfsigned", "")
+
+        with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
+            cfg.write(cfgfile)
+
+        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+
+    return cfg
 
 
 def strtofloat(txtstr):
@@ -283,6 +298,11 @@ else:
         config.getboolean("settings", "debug"),
         config.getboolean("settings", "notifications"),
     )
+
+    # Upgrade config file if needed
+    config = upgrade_config(config)
+
+    logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 
 # Initialize 3Commas API
 api = init_threecommas_api(config)

--- a/helpers/threecommas.py
+++ b/helpers/threecommas.py
@@ -39,6 +39,7 @@ def init_threecommas_api(cfg):
     return Py3CW(
         key = cfg.get("settings", "3c-apikey"),
         secret = cfg.get("settings", "3c-apisecret"),
+        selfsigned = cfg.get("settings", "3c-apiselfsigned", fallback = ""),
         request_options={
             "request_timeout": 10,
             "nr_of_retries": 3,

--- a/movecontracts.py
+++ b/movecontracts.py
@@ -35,6 +35,7 @@ def load_config():
         "botids": [12345, 67890],
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
+        "3c-apiselfsigned": "Your own generated API key, or empty",
         "notifications": False,
         "notify-urls": ["notify-url1"],
     }
@@ -43,6 +44,20 @@ def load_config():
         cfg.write(cfgfile)
 
     return None
+
+
+def upgrade_config(cfg):
+    """Upgrade config file if needed."""
+
+    if not cfg.has_option("settings", "3c-apiselfsigned"):
+        cfg.set("settings", "3c-apiselfsigned", "")
+
+        with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
+            cfg.write(cfgfile)
+
+        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+
+    return cfg
 
 
 def movecontract_pairs(thebot):
@@ -206,6 +221,9 @@ else:
         config.getboolean("settings", "debug"),
         config.getboolean("settings", "notifications"),
     )
+
+    # Upgrade config file if needed
+    config = upgrade_config(config)
 
     logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
     logger.info(f"Program with update the bot(s) at 00:00:01")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-py3cw==0.0.39
+py3cw==0.1.1
 apprise==1.2.1
 telethon==1.27.0
 beautifulsoup4==4.11.2

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ from setuptools import setup
 setup(
     install_requires=[
         # from requirements.txt
-        'py3cw==0.0.31',
-        'apprise==0.9.5.1',
-        'telethon==1.23.0'
+        'py3cw==0.1.1',
+        'apprise==1.2.1',
+        'telethon==1.27.0'
     ],
 )

--- a/tpincrement.py
+++ b/tpincrement.py
@@ -30,6 +30,7 @@ def load_config():
         "increment-step-scale": [0.10, 0.05, 0.05, 0.05, 0.05, 0.05],
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
+        "3c-apiselfsigned": "Your own generated API key, or empty",
         "notifications": False,
         "notify-urls": ["notify-url1"],
     }
@@ -40,7 +41,7 @@ def load_config():
     return None
 
 
-def upgrade_config(thelogger, cfg):
+def upgrade_config(cfg):
     """Upgrade config file if needed."""
 
     try:
@@ -53,7 +54,15 @@ def upgrade_config(thelogger, cfg):
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        thelogger.info("Upgraded the configuration file")
+        logger.info("Upgraded the configuration file")
+
+    if not cfg.has_option("settings", "3c-apiselfsigned"):
+        cfg.set("settings", "3c-apiselfsigned", "")
+
+        with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
+            cfg.write(cfgfile)
+
+        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
 
     return cfg
 
@@ -217,7 +226,7 @@ else:
     )
 
     # Upgrade config file if needed
-    config = upgrade_config(logger, config)
+    config = upgrade_config(config)
 
     logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 

--- a/trailingstoploss.py
+++ b/trailingstoploss.py
@@ -31,6 +31,7 @@ def load_config():
         "initial-stoploss-percentage": "[]",
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
+        "3c-apiselfsigned": "Your own generated API key, or empty",
         "notifications": False,
         "notify-urls": ["notify-url1"],
     }
@@ -41,7 +42,7 @@ def load_config():
     return None
 
 
-def upgrade_config(thelogger, cfg):
+def upgrade_config(cfg):
     """Upgrade config file if needed."""
 
     try:
@@ -51,7 +52,15 @@ def upgrade_config(thelogger, cfg):
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        thelogger.info("Upgraded the configuration file")
+        logger.info("Upgraded the configuration file")
+
+    if not cfg.has_option("settings", "3c-apiselfsigned"):
+        cfg.set("settings", "3c-apiselfsigned", "")
+
+        with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
+            cfg.write(cfgfile)
+
+        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
 
     return cfg
 
@@ -241,7 +250,7 @@ else:
     )
 
     # Upgrade config file if needed
-    config = upgrade_config(logger, config)
+    config = upgrade_config(config)
 
     logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 

--- a/trailingstoploss_tp.py
+++ b/trailingstoploss_tp.py
@@ -60,6 +60,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
+        "3c-apiselfsigned": "Your own generated API key, or empty",
         "notifications": False,
         "notify-urls": ["notify-url1"],
         "notify-trailing-start": True,
@@ -203,6 +204,14 @@ def upgrade_config(thelogger, cfg):
             cfg.write(cfgfile)
 
         thelogger.info("Updates settings to add notify options")
+
+    if not cfg.has_option("settings", "3c-apiselfsigned"):
+        cfg.set("settings", "3c-apiselfsigned", "")
+
+        with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
+            cfg.write(cfgfile)
+
+        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
 
     return cfg
 

--- a/watchlist.py
+++ b/watchlist.py
@@ -34,6 +34,7 @@ def load_config():
         "btc-botids": [12345, 67890],
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
+        "3c-apiselfsigned": "Your own generated API key, or empty",
         "tgram-phone-number": "Your Telegram Phone number",
         "tgram-channel": "Telegram Channel to watch",
         "tgram-api-id": "Your Telegram API ID",
@@ -46,6 +47,20 @@ def load_config():
         cfg.write(cfgfile)
 
     return None
+
+
+def upgrade_config(cfg):
+    """Upgrade config file if needed."""
+
+    if not cfg.has_option("settings", "3c-apiselfsigned"):
+        cfg.set("settings", "3c-apiselfsigned", "")
+
+        with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
+            cfg.write(cfgfile)
+
+        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+
+    return cfg
 
 
 async def handle_custom_event(event):
@@ -169,6 +184,11 @@ else:
         config.getboolean("settings", "debug"),
         config.getboolean("settings", "notifications"),
     )
+
+    # Upgrade config file if needed
+    config = upgrade_config(config)
+
+    logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 
 # Initialize 3Commas API
 api = init_threecommas_api(config)

--- a/watchlist_100eyes.py
+++ b/watchlist_100eyes.py
@@ -39,6 +39,7 @@ def load_config():
         "btc-botids": [12345, 67890],
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
+        "3c-apiselfsigned": "Your own generated API key, or empty",
         "tgram-phone-number": "Your Telegram Phone number",
         "tgram-channel": "Telegram Channel to watch",
         "tgram-api-id": "Your Telegram API ID",
@@ -57,6 +58,20 @@ def load_config():
         cfg.write(cfgfile)
 
     return None
+
+
+def upgrade_config(cfg):
+    """Upgrade config file if needed."""
+
+    if not cfg.has_option("settings", "3c-apiselfsigned"):
+        cfg.set("settings", "3c-apiselfsigned", "")
+
+        with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
+            cfg.write(cfgfile)
+
+        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+
+    return cfg
 
 
 def watchlist_100eyes_deal(thebot, base, coin):
@@ -182,6 +197,10 @@ else:
         config.getboolean("settings", "debug"),
         config.getboolean("settings", "notifications"),
     )
+
+    # Upgrade config file if needed
+    config = upgrade_config(config)
+
     logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 
 # Initialize 3Commas API

--- a/watchlist_hodloo.py
+++ b/watchlist_hodloo.py
@@ -32,6 +32,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
+        "3c-apiselfsigned": "Your own generated API key, or empty",
         "tgram-phone-number": "Your Telegram Phone number",
         "tgram-api-id": "Your Telegram API ID",
         "tgram-api-hash": "Your Telegram API Hash",
@@ -63,6 +64,20 @@ def load_config():
         cfg.write(cfgfile)
 
     return None
+
+
+def upgrade_config(cfg):
+    """Upgrade config file if needed."""
+
+    if not cfg.has_option("settings", "3c-apiselfsigned"):
+        cfg.set("settings", "3c-apiselfsigned", "")
+
+        with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
+            cfg.write(cfgfile)
+
+        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+
+    return cfg
 
 
 async def handle_hodloo_event(category, event):
@@ -161,6 +176,11 @@ else:
         config.getboolean("settings", "debug"),
         config.getboolean("settings", "notifications"),
     )
+
+    # Upgrade config file if needed
+    config = upgrade_config(config)
+
+    logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 
 # Which Exchange to use?
 exchange = config.get("settings", "exchange")

--- a/watchlist_telegram.py
+++ b/watchlist_telegram.py
@@ -48,6 +48,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
+        "3c-apiselfsigned": "Your own generated API key, or empty",
         "tgram-phone-number": "Your Telegram Phone number",
         "tgram-api-id": "Your Telegram API ID",
         "tgram-api-hash": "Your Telegram API Hash",
@@ -93,7 +94,7 @@ def load_config():
     return None
 
 
-def upgrade_config(thelogger, cfg):
+def upgrade_config(cfg):
     """Upgrade config file if needed."""
 
     if not cfg.has_section("smarttrade"):
@@ -106,7 +107,15 @@ def upgrade_config(thelogger, cfg):
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        thelogger.info("Upgraded the configuration file (added smarttrade section)")
+        logger.info("Upgraded the configuration file (added smarttrade section)")
+
+    if not cfg.has_option("settings", "3c-apiselfsigned"):
+        cfg.set("settings", "3c-apiselfsigned", "")
+
+        with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
+            cfg.write(cfgfile)
+
+        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
 
     return cfg
 
@@ -546,7 +555,7 @@ else:
     )
 
 # Upgrade config file if needed
-config = upgrade_config(logger, config)
+config = upgrade_config(config)
 
 # Validation of data before starting
 hl5exchange = config.get("hodloo_5", "exchange")

--- a/webhook.py
+++ b/webhook.py
@@ -38,6 +38,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
+        "3c-apiselfsigned": "Your own generated API key, or empty",
         "notifications": False,
         "notify-urls": ["notify-url1"],
     }
@@ -62,6 +63,20 @@ def load_config():
         cfg.write(cfgfile)
 
     return None
+
+
+def upgrade_config(cfg):
+    """Upgrade config file if needed."""
+
+    if not cfg.has_option("settings", "3c-apiselfsigned"):
+        cfg.set("settings", "3c-apiselfsigned", "")
+
+        with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
+            cfg.write(cfgfile)
+
+        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+
+    return cfg
 
 
 # Start application
@@ -121,6 +136,10 @@ else:
         config.getboolean("settings", "debug"),
         config.getboolean("settings", "notifications"),
     )
+
+    # Upgrade config file if needed
+    config = upgrade_config(config)
+
     logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 
 


### PR DESCRIPTION
Latest py3cw library is required, and it can be used with a self-signed key so I've added this option to all scripts.