### PR TITLE
Refactor of apikey to reading file for the contents

### DIFF
--- a/allpairs.py
+++ b/allpairs.py
@@ -33,7 +33,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
-        "3c-apiselfsigned": "Your own generated API key, or empty",
+        "3c-apikey-path": "Path to your own generated RSA private key, or empty",
         "notifications": False,
         "notify-urls": ["notify-url1"],
         "botids": [12345, 67890],
@@ -48,13 +48,13 @@ def load_config():
 def upgrade_config(cfg):
     """Upgrade config file if needed."""
 
-    if not cfg.has_option("settings", "3c-apiselfsigned"):
-        cfg.set("settings", "3c-apiselfsigned", "")
+    if not cfg.has_option("settings", "3c-apikey-path"):
+        cfg.set("settings", "3c-apikey-path", "")
 
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+        logger.info("Upgraded the configuration file (3c-apikey-path)")
 
     return cfg
 
@@ -177,7 +177,9 @@ else:
     logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 
 # Initialize 3Commas API
-api = init_threecommas_api(config)
+api = init_threecommas_api(logger, config)
+if not api:
+    sys.exit(0)
 
 # Refresh all pairs
 while True:

--- a/altrank.py
+++ b/altrank.py
@@ -44,7 +44,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
-        "3c-apiselfsigned": "Your own generated API key, or empty",
+        "3c-apikey-path": "Path to your own generated RSA private key, or empty",
         "lc-apikey": "Your LunarCrush API Key",
         "lc-fetchlimit": 150,
         "notifications": False,
@@ -84,13 +84,13 @@ def upgrade_config(cfg):
 
             logger.info("Upgraded the configuration file (bot stop-start)")
 
-    if not cfg.has_option("settings", "3c-apiselfsigned"):
-        cfg.set("settings", "3c-apiselfsigned", "")
+    if not cfg.has_option("settings", "3c-apikey-path"):
+        cfg.set("settings", "3c-apikey-path", "")
 
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+        logger.info("Upgraded the configuration file (3c-apikey-path)")
 
     return cfg
 
@@ -308,7 +308,9 @@ else:
     logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 
 # Initialize 3Commas API
-api = init_threecommas_api(config)
+api = init_threecommas_api(logger, config)
+if not api:
+    sys.exit(0)
 
 logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 

--- a/balancereport.py
+++ b/balancereport.py
@@ -44,7 +44,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
-        "3c-apiselfsigned": "Your own generated API key, or empty",
+        "3c-apikey-path": "Path to your own generated RSA private key, or empty",
         "notifications": False,
         "notify-urls": ["notify-url1"],
         "conditional-botids": [],
@@ -67,13 +67,13 @@ def upgrade_config(cfg):
 
         logger.info("Upgraded section settings to have conditional-botids")
 
-    if not cfg.has_option("settings", "3c-apiselfsigned"):
-        cfg.set("settings", "3c-apiselfsigned", "")
+    if not cfg.has_option("settings", "3c-apikey-path"):
+        cfg.set("settings", "3c-apikey-path", "")
 
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+        logger.info("Upgraded the configuration file (3c-apikey-path)")
 
     return cfg
 
@@ -545,7 +545,9 @@ else:
     logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 
 # Initialize 3Commas API
-api = init_threecommas_api(config)
+api = init_threecommas_api(logger, config)
+if not api:
+    sys.exit(0)
 
 # Create balance report
 while True:

--- a/botassistexplorer.py
+++ b/botassistexplorer.py
@@ -42,7 +42,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
-        "3c-apiselfsigned": "Your own generated API key, or empty",
+        "3c-apikey-path": "Path to your own generated RSA private key, or empty",
         "notifications": False,
         "notify-urls": ["notify-url1"],
     }
@@ -106,13 +106,13 @@ def upgrade_config(cfg):
 
                 logger.info("Upgraded the configuration file (allowpairconversion)")
 
-    if not cfg.has_option("settings", "3c-apiselfsigned"):
-        cfg.set("settings", "3c-apiselfsigned", "")
+    if not cfg.has_option("settings", "3c-apikey-path"):
+        cfg.set("settings", "3c-apikey-path", "")
 
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+        logger.info("Upgraded the configuration file (3c-apikey-path)")
 
     return cfg
 
@@ -351,7 +351,9 @@ else:
     logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 
 # Initialize 3Commas API
-api = init_threecommas_api(config)
+api = init_threecommas_api(logger, config)
+if not api:
+    sys.exit(0)
 
 # Refresh coin pairs based on CoinMarketCap data
 while True:

--- a/botupdater.py
+++ b/botupdater.py
@@ -44,7 +44,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
-        "3c-apiselfsigned": "Your own generated API key, or empty",
+        "3c-apikey-path": "Path to your own generated RSA private key, or empty",
         "notifications": False,
         "notify-urls": ["notify-url1"],
     }
@@ -144,13 +144,13 @@ def upgrade_config(cfg):
 
             logger.info("Upgraded section %s to have notify option" % cfgsection)
 
-    if not cfg.has_option("settings", "3c-apiselfsigned"):
-        cfg.set("settings", "3c-apiselfsigned", "")
+    if not cfg.has_option("settings", "3c-apikey-path"):
+        cfg.set("settings", "3c-apikey-path", "")
 
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+        logger.info("Upgraded the configuration file (3c-apikey-path)")
 
     return cfg
 
@@ -751,7 +751,9 @@ else:
     logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 
 # Initialize 3Commas API
-api = init_threecommas_api(config)
+api = init_threecommas_api(logger, config)
+if not api:
+    sys.exit(0)
 
 # Initialize or open the database
 db = open_bu_db()

--- a/coinmarketcap.py
+++ b/coinmarketcap.py
@@ -46,7 +46,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
-        "3c-apiselfsigned": "Your own generated API key, or empty",
+        "3c-apikey-path": "Path to your own generated RSA private key, or empty",
         "cmc-apikey": "Your CoinMarketCap API Key",
         "notifications": False,
         "notify-urls": ["notify-url1"],
@@ -124,13 +124,13 @@ def upgrade_config(cfg):
                     "Upgraded the configuration file (max-percent-change)"
                 )
 
-    if not cfg.has_option("settings", "3c-apiselfsigned"):
-        cfg.set("settings", "3c-apiselfsigned", "")
+    if not cfg.has_option("settings", "3c-apikey-path"):
+        cfg.set("settings", "3c-apikey-path", "")
 
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+        logger.info("Upgraded the configuration file (3c-apikey-path)")
 
     return cfg
 
@@ -371,7 +371,9 @@ else:
     logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 
 # Initialize 3Commas API
-api = init_threecommas_api(config)
+api = init_threecommas_api(logger, config)
+if not api:
+    sys.exit(0)
 
 # Initialize or open the database
 db = open_cmc_db()

--- a/compound.py
+++ b/compound.py
@@ -39,7 +39,7 @@ def load_config():
         "default-profittocompound": 1.0,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
-        "3c-apiselfsigned": "Your own generated API key, or empty",
+        "3c-apikey-path": "Path to your own generated RSA private key, or empty",
         "notifications": False,
         "notify-urls": ["notify-url1", "notify-url2"],
     }
@@ -112,13 +112,13 @@ def upgrade_config(theapi, cfg):
 
         logger.info("Upgraded the configuration file (create sections)")
 
-    if not cfg.has_option("settings", "3c-apiselfsigned"):
-        cfg.set("settings", "3c-apiselfsigned", "")
+    if not cfg.has_option("settings", "3c-apikey-path"):
+        cfg.set("settings", "3c-apikey-path", "")
 
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+        logger.info("Upgraded the configuration file (3c-apikey-path)")
 
     return cfg
 
@@ -874,7 +874,9 @@ else:
 
 
 # Initialize 3Commas API
-api = init_threecommas_api(config)
+api = init_threecommas_api(logger, config)
+if not api:
+    sys.exit(0)
 
 # Upgrade config file if needed
 config = upgrade_config(api, config)

--- a/dealcluster.py
+++ b/dealcluster.py
@@ -42,7 +42,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
-        "3c-apiselfsigned": "Your own generated API key, or empty",
+        "3c-apikey-path": "Path to your own generated RSA private key, or empty",
         "notifications": False,
         "notify-urls": ["notify-url1"],
     }
@@ -61,13 +61,13 @@ def load_config():
 def upgrade_config(cfg):
     """Upgrade config file if needed."""
 
-    if not cfg.has_option("settings", "3c-apiselfsigned"):
-        cfg.set("settings", "3c-apiselfsigned", "")
+    if not cfg.has_option("settings", "3c-apikey-path"):
+        cfg.set("settings", "3c-apikey-path", "")
 
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+        logger.info("Upgraded the configuration file (3c-apikey-path)")
 
     return cfg
 
@@ -532,7 +532,9 @@ else:
     logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 
 # Initialize 3Commas API
-api = init_threecommas_api(config)
+api = init_threecommas_api(logger, config)
+if not api:
+    sys.exit(0)
 
 # Initialize or open the database
 db = init_cluster_db()

--- a/galaxyscore.py
+++ b/galaxyscore.py
@@ -44,7 +44,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
-        "3c-apiselfsigned": "Your own generated API key, or empty",
+        "3c-apikey-path": "Path to your own generated RSA private key, or empty",
         "lc-apikey": "Your LunarCrush API Key",
         "lc-fetchlimit": 150,
         "notifications": False,
@@ -86,13 +86,13 @@ def upgrade_config(cfg):
 
             logger.info("Upgraded the configuration file (mingalaxyscore and bot stop-start)")
 
-    if not cfg.has_option("settings", "3c-apiselfsigned"):
-        cfg.set("settings", "3c-apiselfsigned", "")
+    if not cfg.has_option("settings", "3c-apikey-path"):
+        cfg.set("settings", "3c-apikey-path", "")
 
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+        logger.info("Upgraded the configuration file (3c-apikey-path)")
 
     return cfg
 
@@ -320,7 +320,9 @@ else:
     logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 
 # Initialize 3Commas API
-api = init_threecommas_api(config)
+api = init_threecommas_api(logger, config)
+if not api:
+    sys.exit(0)
 
 logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 

--- a/gridbot.py
+++ b/gridbot.py
@@ -31,7 +31,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
-        "3c-apiselfsigned": "Your own generated API key, or empty",
+        "3c-apikey-path": "Path to your own generated RSA private key, or empty",
         "notifications": False,
         "notify-urls": ["notify-url1", "notify-url2"],
     }
@@ -55,13 +55,13 @@ def load_config():
 def upgrade_config(cfg):
     """Upgrade config file if needed."""
 
-    if not cfg.has_option("settings", "3c-apiselfsigned"):
-        cfg.set("settings", "3c-apiselfsigned", "")
+    if not cfg.has_option("settings", "3c-apikey-path"):
+        cfg.set("settings", "3c-apikey-path", "")
 
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+        logger.info("Upgraded the configuration file (3c-apikey-path)")
 
     return cfg
 
@@ -305,7 +305,9 @@ else:
     logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 
 # Initialize 3Commas API
-api = init_threecommas_api(config)
+api = init_threecommas_api(logger, config)
+if not api:
+    sys.exit(0)
 
 # Auto tune a running gridbot
 while True:

--- a/movecontracts.py
+++ b/movecontracts.py
@@ -35,7 +35,7 @@ def load_config():
         "botids": [12345, 67890],
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
-        "3c-apiselfsigned": "Your own generated API key, or empty",
+        "3c-apikey-path": "Path to your own generated RSA private key, or empty",
         "notifications": False,
         "notify-urls": ["notify-url1"],
     }
@@ -49,13 +49,13 @@ def load_config():
 def upgrade_config(cfg):
     """Upgrade config file if needed."""
 
-    if not cfg.has_option("settings", "3c-apiselfsigned"):
-        cfg.set("settings", "3c-apiselfsigned", "")
+    if not cfg.has_option("settings", "3c-apikey-path"):
+        cfg.set("settings", "3c-apikey-path", "")
 
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+        logger.info("Upgraded the configuration file (3c-apikey-path)")
 
     return cfg
 
@@ -229,7 +229,9 @@ else:
     logger.info(f"Program with update the bot(s) at 00:00:01")
 
 # Initialize 3Commas API
-api = init_threecommas_api(config)
+api = init_threecommas_api(logger, config)
+if not api:
+    sys.exit(0)
 
 # MOVE contract pairs
 def schedule_bots():

--- a/tpincrement.py
+++ b/tpincrement.py
@@ -30,7 +30,7 @@ def load_config():
         "increment-step-scale": [0.10, 0.05, 0.05, 0.05, 0.05, 0.05],
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
-        "3c-apiselfsigned": "Your own generated API key, or empty",
+        "3c-apikey-path": "Path to your own generated RSA private key, or empty",
         "notifications": False,
         "notify-urls": ["notify-url1"],
     }
@@ -56,13 +56,13 @@ def upgrade_config(cfg):
 
         logger.info("Upgraded the configuration file")
 
-    if not cfg.has_option("settings", "3c-apiselfsigned"):
-        cfg.set("settings", "3c-apiselfsigned", "")
+    if not cfg.has_option("settings", "3c-apikey-path"):
+        cfg.set("settings", "3c-apikey-path", "")
 
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+        logger.info("Upgraded the configuration file (3c-apikey-path)")
 
     return cfg
 
@@ -231,7 +231,9 @@ else:
     logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 
 # Initialize 3Commas API
-api = init_threecommas_api(config)
+api = init_threecommas_api(logger, config)
+if not api:
+    sys.exit(0)
 
 # Initialize or open the database
 db = init_tpincrement_db()

--- a/trailingstoploss.py
+++ b/trailingstoploss.py
@@ -31,7 +31,7 @@ def load_config():
         "initial-stoploss-percentage": "[]",
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
-        "3c-apiselfsigned": "Your own generated API key, or empty",
+        "3c-apikey-path": "Path to your own generated RSA private key, or empty",
         "notifications": False,
         "notify-urls": ["notify-url1"],
     }
@@ -54,13 +54,13 @@ def upgrade_config(cfg):
 
         logger.info("Upgraded the configuration file")
 
-    if not cfg.has_option("settings", "3c-apiselfsigned"):
-        cfg.set("settings", "3c-apiselfsigned", "")
+    if not cfg.has_option("settings", "3c-apikey-path"):
+        cfg.set("settings", "3c-apikey-path", "")
 
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+        logger.info("Upgraded the configuration file (3c-apikey-path)")
 
     return cfg
 
@@ -255,7 +255,9 @@ else:
     logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 
 # Initialize 3Commas API
-api = init_threecommas_api(config)
+api = init_threecommas_api(logger, config)
+if not api:
+    sys.exit(0)
 
 # Initialize or open the database
 db = init_tsl_db()

--- a/trailingstoploss_tp.py
+++ b/trailingstoploss_tp.py
@@ -60,7 +60,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
-        "3c-apiselfsigned": "Your own generated API key, or empty",
+        "3c-apikey-path": "Path to your own generated RSA private key, or empty",
         "notifications": False,
         "notify-urls": ["notify-url1"],
         "notify-trailing-start": True,
@@ -205,13 +205,13 @@ def upgrade_config(thelogger, cfg):
 
         thelogger.info("Updates settings to add notify options")
 
-    if not cfg.has_option("settings", "3c-apiselfsigned"):
-        cfg.set("settings", "3c-apiselfsigned", "")
+    if not cfg.has_option("settings", "3c-apikey-path"):
+        cfg.set("settings", "3c-apikey-path", "")
 
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+        logger.info("Upgraded the configuration file (3c-apikey-path)")
 
     return cfg
 
@@ -1331,7 +1331,9 @@ else:
     logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 
 # Initialize 3Commas API
-api = init_threecommas_api(config)
+api = init_threecommas_api(logger, config)
+if not api:
+    sys.exit(0)
 
 # Initialize or open the database
 db = open_tsl_db()

--- a/watchlist.py
+++ b/watchlist.py
@@ -34,7 +34,7 @@ def load_config():
         "btc-botids": [12345, 67890],
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
-        "3c-apiselfsigned": "Your own generated API key, or empty",
+        "3c-apikey-path": "Path to your own generated RSA private key, or empty",
         "tgram-phone-number": "Your Telegram Phone number",
         "tgram-channel": "Telegram Channel to watch",
         "tgram-api-id": "Your Telegram API ID",
@@ -52,13 +52,13 @@ def load_config():
 def upgrade_config(cfg):
     """Upgrade config file if needed."""
 
-    if not cfg.has_option("settings", "3c-apiselfsigned"):
-        cfg.set("settings", "3c-apiselfsigned", "")
+    if not cfg.has_option("settings", "3c-apikey-path"):
+        cfg.set("settings", "3c-apikey-path", "")
 
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+        logger.info("Upgraded the configuration file (3c-apikey-path)")
 
     return cfg
 
@@ -191,7 +191,9 @@ else:
     logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 
 # Initialize 3Commas API
-api = init_threecommas_api(config)
+api = init_threecommas_api(logger, config)
+if not api:
+    sys.exit(0)
 
 # Prefetch marketcodes for all bots
 botids = json.loads(config.get("settings", "usdt-botids")) + json.loads(config.get("settings", "btc-botids"))

--- a/watchlist_100eyes.py
+++ b/watchlist_100eyes.py
@@ -39,7 +39,7 @@ def load_config():
         "btc-botids": [12345, 67890],
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
-        "3c-apiselfsigned": "Your own generated API key, or empty",
+        "3c-apikey-path": "Path to your own generated RSA private key, or empty",
         "tgram-phone-number": "Your Telegram Phone number",
         "tgram-channel": "Telegram Channel to watch",
         "tgram-api-id": "Your Telegram API ID",
@@ -63,13 +63,13 @@ def load_config():
 def upgrade_config(cfg):
     """Upgrade config file if needed."""
 
-    if not cfg.has_option("settings", "3c-apiselfsigned"):
-        cfg.set("settings", "3c-apiselfsigned", "")
+    if not cfg.has_option("settings", "3c-apikey-path"):
+        cfg.set("settings", "3c-apikey-path", "")
 
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+        logger.info("Upgraded the configuration file (3c-apikey-path)")
 
     return cfg
 
@@ -204,7 +204,9 @@ else:
     logger.info(f"Loaded configuration from '{datadir}/{program}.ini'")
 
 # Initialize 3Commas API
-api = init_threecommas_api(config)
+api = init_threecommas_api(logger, config)
+if not api:
+    sys.exit(0)
 
 # Get trigger settings from config
 triggers = list(config["triggers"].keys())

--- a/watchlist_hodloo.py
+++ b/watchlist_hodloo.py
@@ -32,7 +32,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
-        "3c-apiselfsigned": "Your own generated API key, or empty",
+        "3c-apikey-path": "Path to your own generated RSA private key, or empty",
         "tgram-phone-number": "Your Telegram Phone number",
         "tgram-api-id": "Your Telegram API ID",
         "tgram-api-hash": "Your Telegram API Hash",
@@ -69,13 +69,13 @@ def load_config():
 def upgrade_config(cfg):
     """Upgrade config file if needed."""
 
-    if not cfg.has_option("settings", "3c-apiselfsigned"):
-        cfg.set("settings", "3c-apiselfsigned", "")
+    if not cfg.has_option("settings", "3c-apikey-path"):
+        cfg.set("settings", "3c-apikey-path", "")
 
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+        logger.info("Upgraded the configuration file (3c-apikey-path)")
 
     return cfg
 
@@ -199,7 +199,9 @@ if mode not in ("Telegram", "Websocket"):
     sys.exit(0)
 
 # Initialize 3Commas API
-api = init_threecommas_api(config)
+api = init_threecommas_api(logger, config)
+if not api:
+    sys.exit(0)
 
 # Prefetch marketcodes for all bots
 botids = list()

--- a/watchlist_telegram.py
+++ b/watchlist_telegram.py
@@ -48,7 +48,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
-        "3c-apiselfsigned": "Your own generated API key, or empty",
+        "3c-apikey-path": "Path to your own generated RSA private key, or empty",
         "tgram-phone-number": "Your Telegram Phone number",
         "tgram-api-id": "Your Telegram API ID",
         "tgram-api-hash": "Your Telegram API Hash",
@@ -109,13 +109,13 @@ def upgrade_config(cfg):
 
         logger.info("Upgraded the configuration file (added smarttrade section)")
 
-    if not cfg.has_option("settings", "3c-apiselfsigned"):
-        cfg.set("settings", "3c-apiselfsigned", "")
+    if not cfg.has_option("settings", "3c-apikey-path"):
+        cfg.set("settings", "3c-apikey-path", "")
 
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+        logger.info("Upgraded the configuration file (3c-apikey-path)")
 
     return cfg
 
@@ -573,7 +573,9 @@ if hl10exchange not in ("Bittrex", "Binance", "Kucoin"):
     sys.exit(0)
 
 # Initialize 3Commas API
-api = init_threecommas_api(config)
+api = init_threecommas_api(logger, config)
+if not api:
+    sys.exit(0)
 
 # Code to enable testing instead of waiting for events.
 #run_tests()

--- a/webhook.py
+++ b/webhook.py
@@ -38,7 +38,7 @@ def load_config():
         "logrotate": 7,
         "3c-apikey": "Your 3Commas API Key",
         "3c-apisecret": "Your 3Commas API Secret",
-        "3c-apiselfsigned": "Your own generated API key, or empty",
+        "3c-apikey-path": "Path to your own generated RSA private key, or empty",
         "notifications": False,
         "notify-urls": ["notify-url1"],
     }
@@ -68,13 +68,13 @@ def load_config():
 def upgrade_config(cfg):
     """Upgrade config file if needed."""
 
-    if not cfg.has_option("settings", "3c-apiselfsigned"):
-        cfg.set("settings", "3c-apiselfsigned", "")
+    if not cfg.has_option("settings", "3c-apikey-path"):
+        cfg.set("settings", "3c-apikey-path", "")
 
         with open(f"{datadir}/{program}.ini", "w+") as cfgfile:
             cfg.write(cfgfile)
 
-        logger.info("Upgraded the configuration file (3c-apiselfsigned)")
+        logger.info("Upgraded the configuration file (3c-apikey-path)")
 
     return cfg
 
@@ -209,7 +209,10 @@ def webhook_deal(thebot, coin, trade):
 
 
 # Initialize 3Commas API
-api = init_threecommas_api(config)
+api = init_threecommas_api(logger, config)
+if not api:
+    sys.exit(0)
+
 blacklist = load_blacklist(logger, api, blacklistfile)
 
 # Webserver app


### PR DESCRIPTION
Previous implementation was too quick. Having the RSA key content in the *.ini file is not handy and does require some escaping for the Python Config module to be able to load it. Specify the path to the *.pem file is much cleaner and allows for easier reuse, so refactored the code a bit.