### PR TITLE
Fix Process Botlist is in Helpers

### DIFF
--- a/watchlist_hodloo.py
+++ b/watchlist_hodloo.py
@@ -16,7 +16,7 @@ from helpers.threecommas import (
     load_blacklist,
     prefetch_marketcodes
 )
-from watchlist import process_botlist
+from helpers.watchlist import process_botlist
 
 
 def load_config():


### PR DESCRIPTION
open helpers.watchlist to import process_botlist.
with this change it will not start watchlist.py correctly